### PR TITLE
update juno components

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     }
   },
   "dependencies": {
-    "@cloudoperators/juno-ui-components": "2.22.1",
+    "@cloudoperators/juno-ui-components": "2.34.0",
     "@cloudoperators/juno-url-state-provider": "*",
     "@cloudoperators/juno-utils": "*",
     "cypress": "^13.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sapcc/limes-ui",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": "VoigtS",
   "license": "MIT",
   "source": "src/index.js",

--- a/src/components/commitment/Operations/Actions.test.js
+++ b/src/components/commitment/Operations/Actions.test.js
@@ -56,7 +56,7 @@ describe("test Action Operation", () => {
     });
     fireEvent.click(contextMenu);
     await waitFor(() => {
-      expect(screen.queryByTitle(/delete/i)).not.toBe(null);
+      expect(screen.queryByText("Delete")).not.toBe(null);
     });
   });
 
@@ -88,9 +88,9 @@ describe("test Action Operation", () => {
     const contextMenu = await waitFor(() => {
       return screen.getByTitle(/more/i);
     });
-    fireEvent.click(contextMenu);
     await waitFor(() => {
-      expect(screen.queryByTitle(/convert/i)).not.toBe(null);
+      fireEvent.click(contextMenu);
+      expect(screen.queryByText(/convert/i)).not.toBe(null);
     });
   });
 
@@ -126,7 +126,7 @@ describe("test Action Operation", () => {
     });
     fireEvent.click(contextMenu);
     await waitFor(() => {
-      expect(screen.queryByTitle(/transfer/i)).not.toBe(null);
+      expect(screen.queryByText(/transfer/i)).not.toBe(null);
     });
   });
   test("should render duration update action", async () => {
@@ -159,7 +159,7 @@ describe("test Action Operation", () => {
     });
     fireEvent.click(contextMenu);
     await waitFor(() => {
-      expect(screen.queryByTitle(/edit/i)).not.toBe(null);
+      expect(screen.queryByText(/edit/i)).not.toBe(null);
     });
   });
 });

--- a/src/components/commitment/Operations/MenuItemBuilder.js
+++ b/src/components/commitment/Operations/MenuItemBuilder.js
@@ -19,7 +19,8 @@ import { MenuItem } from "@cloudoperators/juno-ui-components";
 const MenuItemBuilder = (props) => {
   const { icon, text, callBack } = props;
 
-  // TODO: Junos newest version breaks the old handling of the MenuItem. If children are delivered, it will always be treated as a uninteractable <div>. Listeners will be ignored.
+  // Junos newest version breaks the old handling of the MenuItem. If children are delivered, it will always be treated as a uninteractable <div>. Listeners will be ignored.
+  // TODO: Add a test case which calls the modal the menuItem is supposed to call.
   // As a workaround we comply to these changes and implement a workaround which results in icons to always have the default color. This means the Transfor icon won't be indicating in which state it is now.
   return (
     <MenuItem

--- a/src/components/commitment/Operations/MenuItemBuilder.js
+++ b/src/components/commitment/Operations/MenuItemBuilder.js
@@ -15,33 +15,21 @@
  */
 
 import React from "react";
-import { Stack, Icon, MenuItem } from "@cloudoperators/juno-ui-components";
-import { getChildrenOnDisplayName } from "../../../lib/builderUtils";
+import { MenuItem } from "@cloudoperators/juno-ui-components";
+const MenuItemBuilder = (props) => {
+  const { icon, text, callBack } = props;
 
-const MenuItemBuilder = ({ children, callBack }) => {
-  const icon = getChildrenOnDisplayName(children, "Icon");
-  const text = getChildrenOnDisplayName(children, "Text");
-
+  // TODO: Junos newest version breaks the old handling of the MenuItem. If children are delivered, it will always be treated as a uninteractable <div>. Listeners will be ignored.
+  // As a workaround we comply to these changes and implement a workaround which results in icons to always have the default color. This means the Transfor icon won't be indicating in which state it is now.
   return (
     <MenuItem
       onClick={() => {
         callBack();
       }}
-    >
-      <Stack alignment="center" gap="2">
-        {icon}
-        {text}
-      </Stack>
-    </MenuItem>
+      icon={icon}
+      label={text}
+    ></MenuItem>
   );
 };
-
-const MenuIcon = ({ style, ...other }) => <Icon size="16" {...style} {...other} />;
-MenuIcon.displayName = "Icon";
-MenuItemBuilder.Icon = MenuIcon;
-
-const MenuText = ({ children }) => <span>{children}</span>;
-MenuText.displayName = "Text";
-MenuItemBuilder.Text = MenuText;
 
 export default MenuItemBuilder;

--- a/src/components/commitment/Operations/useConversionAction.js
+++ b/src/components/commitment/Operations/useConversionAction.js
@@ -32,12 +32,7 @@ const useConversionAction = (props) => {
     if (!showConversionOption) return;
     const validFlavors = new RegExp("^instances_hana.").exec(resource_name)?.[0];
     if (!validFlavors) return;
-    const menuItem = (
-      <MenuItemBuilder callBack={convertCommitment}>
-        <MenuItemBuilder.Icon icon="edit" title="Convert" />
-        <MenuItemBuilder.Text>Convert</MenuItemBuilder.Text>
-      </MenuItemBuilder>
-    );
+    const menuItem = <MenuItemBuilder icon="edit" text="Convert" callBack={convertCommitment} />;
     updateActions("convert", menuItem, null);
   }, [resource_name, showConversionOption]);
 };

--- a/src/components/commitment/Operations/useDeleteAction.js
+++ b/src/components/commitment/Operations/useDeleteAction.js
@@ -29,12 +29,7 @@ const useDeleteAction = (props) => {
 
   React.useEffect(() => {
     if (can_be_deleted) {
-      const menuItem = (
-        <MenuItemBuilder callBack={onCommitmentDelete}>
-          <MenuItemBuilder.Icon icon="cancel" title="Delete" />
-          <MenuItemBuilder.Text>Delete</MenuItemBuilder.Text>
-        </MenuItemBuilder>
-      );
+      const menuItem = <MenuItemBuilder icon="cancel" text="Delete" callBack={onCommitmentDelete} />;
       const toolTip = "deletable";
 
       updateActions("delete", menuItem, toolTip);

--- a/src/components/commitment/Operations/useTransferAction.js
+++ b/src/components/commitment/Operations/useTransferAction.js
@@ -33,7 +33,7 @@ const useTransferAction = (props) => {
   }
 
   React.useEffect(() => {
-    if (scope?.isProject() && isConfirmed) {
+    if (scope.isProject() && isConfirmed) {
       const menuItem = (
         <MenuItemBuilder callBack={transferCommitOnProjectLevel}>
           <MenuItemBuilder.Icon

--- a/src/components/commitment/Operations/useTransferAction.js
+++ b/src/components/commitment/Operations/useTransferAction.js
@@ -35,14 +35,11 @@ const useTransferAction = (props) => {
   React.useEffect(() => {
     if (scope.isProject() && isConfirmed) {
       const menuItem = (
-        <MenuItemBuilder callBack={transferCommitOnProjectLevel}>
-          <MenuItemBuilder.Icon
-            icon="upload"
-            title="Transfer"
-            color={commitmentInTrasfer ? "jn-text-theme-info" : "jn-global-text"}
-          />
-          <MenuItemBuilder.Text>Transfer</MenuItemBuilder.Text>
-        </MenuItemBuilder>
+        <MenuItemBuilder
+          icon="upload"
+          text={commitmentInTrasfer ? "Transferring" : "Transfer"}
+          callBack={transferCommitOnProjectLevel}
+        />
       );
       let toolTip = null;
       if (commitmentInTrasfer) {

--- a/src/components/commitment/Operations/useUpdateDurationAction.js
+++ b/src/components/commitment/Operations/useUpdateDurationAction.js
@@ -39,12 +39,7 @@ const useUpdateDurationAction = (props) => {
   React.useEffect(() => {
     if (validDurations.length == 0) return;
     addValidDuration({ id: commitment.id, durations: validDurations });
-    const menuItem = (
-      <MenuItemBuilder callBack={updateDuration}>
-        <MenuItemBuilder.Icon icon="edit" />
-        <MenuItemBuilder.Text>Duration</MenuItemBuilder.Text>
-      </MenuItemBuilder>
-    );
+    const menuItem = <MenuItemBuilder icon="edit" text="Duration" callBack={updateDuration} />;
     updateActions("durationUpdate", menuItem, null);
   }, [commitment]);
 };

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -101,7 +101,7 @@ const Resource = (props) => {
     editableResource,
   } = props.resource;
   const { scope } = globalStore();
-  const { tracksQuota, isPanelView, subRoute } = {
+  const { tracksQuota, isPanelView, subRoute, setCurrentAZ } = {
     ...props,
   };
   const displayName = t(props.resource.name);
@@ -195,7 +195,8 @@ const Resource = (props) => {
                 }`}
                 onClick={() => {
                   if (!props.isPanelView || subRoute || azName == "unknown") return;
-                  resetCommitment(az);
+                  setCurrentAZ(azName);
+                  resetCommitment();
                 }}
               >
                 <div className={`az-title ${azTitle} flex justify-between`}>

--- a/src/components/panel/AvailabilityZoneNav.js
+++ b/src/components/panel/AvailabilityZoneNav.js
@@ -28,18 +28,21 @@ const AvailabilityZoneNav = (props) => {
       <Tabs selectedIndex={azIndex} onSelect={() => {}}>
         <TabList>
           {props.az.map((az) => {
-            const azName = az[0]
-            return azName !== "unknown" && azName !== "any" && (
-              <Tab
-                data-testid={`tab/${azName}`}
-                key={azName}
-                onClick={() => {
-                  setCurrentAZ(azName);
-                  resetCommitment();
-                }}
-              >
-                {az[0]}
-              </Tab>
+            const azName = az[0];
+            return (
+              azName !== "unknown" &&
+              azName !== "any" && (
+                <Tab
+                  data-testid={`tab/${azName}`}
+                  key={azName}
+                  onClick={() => {
+                    setCurrentAZ(azName);
+                    resetCommitment();
+                  }}
+                >
+                  {az[0]}
+                </Tab>
+              )
             );
           })}
         </TabList>

--- a/src/components/panel/AvailabilityZoneNav.js
+++ b/src/components/panel/AvailabilityZoneNav.js
@@ -20,26 +20,28 @@ import useResetCommitment from "../../hooks/useResetCommitment";
 
 const AvailabilityZoneNav = (props) => {
   const azIndex = props.az.findIndex((az) => az[0] === props.currentAZ);
+  const { setCurrentAZ } = props;
   const { resetCommitment } = useResetCommitment();
 
   return (
     <Container px={false} className="pt-0 py-6 sticky top-[2rem] bg-juno-grey-light-1 z-[100]">
       <Tabs selectedIndex={azIndex} onSelect={() => {}}>
         <TabList>
-          {props.az.map(
-            (az) =>
-              az[0] !== "unknown" &&
-              az[0] !== "any" && (
-                <Tab
-                  key={az}
-                  onClick={() => {
-                    resetCommitment(az);
-                  }}
-                >
-                  {az[0]}
-                </Tab>
-              )
-          )}
+          {props.az.map((az) => {
+            const azName = az[0]
+            return azName !== "unknown" && azName !== "any" && (
+              <Tab
+                data-testid={`tab/${azName}`}
+                key={azName}
+                onClick={() => {
+                  setCurrentAZ(azName);
+                  resetCommitment();
+                }}
+              >
+                {az[0]}
+              </Tab>
+            );
+          })}
         </TabList>
         {props.az.map((az) => az[0] !== "unknown" && az[0] !== "any" && <TabPanel key={az[0]}></TabPanel>)}
       </Tabs>

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -79,7 +79,6 @@ const EditPanel = (props) => {
   const { resetCommitmentTransfer } = useResetCommitment();
   const { commitment: newCommitment } = createCommitmentStore();
   const { toast } = createCommitmentStore();
-  const { currentAZ } = createCommitmentStore();
   const { conversionCommitment } = createCommitmentStore();
   const { currentProject } = createCommitmentStore();
   const { deleteCommitment } = createCommitmentStore();
@@ -88,7 +87,6 @@ const EditPanel = (props) => {
   const { transferFromAndToProject } = createCommitmentStore();
   const { updateDurationCommitment } = createCommitmentStore();
   const { setCommitment } = createCommitmentStoreActions();
-  const { setCurrentAZ } = createCommitmentStoreActions();
   const { setConversionCommitment } = createCommitmentStoreActions();
   const { setDeleteCommitment } = createCommitmentStoreActions();
   const { setIsCommitting } = createCommitmentStoreActions();
@@ -104,15 +102,7 @@ const EditPanel = (props) => {
   const { setRefetchCommitmentAPI } = createCommitmentStoreActions();
   const { setCommitmentIsLoading } = createCommitmentStoreActions();
   const conversionResults = useGetConversions({ serviceType, resourceName });
-
-  React.useEffect(() => {
-    if (!currentAZ) {
-      setCurrentAZ(currentResource.per_az[0][0]);
-    }
-    return () => {
-      setCurrentAZ(null);
-    };
-  }, []);
+  const [currentAZ, setCurrentAZ] = React.useState(currentResource.per_az[0][0]);
 
   // Query can-confirm API. Determine if capacity is sufficient on limes.
   // If a minConfirmDate is set, skip the request. Limes handles capacity concerns.
@@ -404,13 +394,16 @@ const EditPanel = (props) => {
         tracksQuota={tracksQuota}
         isPanelView={true}
         subRoute={subRoute}
+        setCurrentAZ={setCurrentAZ}
       />
       <div className={"sticky top-0 z-[100] bg-juno-grey-light-1 h-8"}>
         {toast.message && (
           <Toast className={"pb-0"} text={toast.message} variant={toast.variant} onDismiss={() => dismissToast()} />
         )}
       </div>
-      {!subRoute && <AvailabilityZoneNav az={currentResource.per_az} currentAZ={currentAZ} />}
+      {!subRoute && (
+        <AvailabilityZoneNav az={currentResource.per_az} currentAZ={currentAZ} setCurrentAZ={setCurrentAZ} />
+      )}
       {scope.isProject() && commitments && (
         <CommitmentTable
           serviceType={serviceType}

--- a/src/components/panel/EditPanel.test.js
+++ b/src/components/panel/EditPanel.test.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2024 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import EditPanel from "./EditPanel";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, screen, waitFor } from "@testing-library/react";
+import { PortalProvider } from "@cloudoperators/juno-ui-components";
+import { Scope } from "../../lib/scope";
+import StoreProvider, {
+  globalStoreActions,
+  clusterStoreActions,
+  domainStoreActions,
+  createCommitmentStore,
+  createCommitmentStoreActions,
+} from "../StoreProvider";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+    },
+  },
+});
+queryClient.setQueryDefaults(["getConversions"], {
+  queryFn: () => {
+    return;
+  },
+});
+
+describe("EditPanel tests", () => {
+  test("AZ selection state", async () => {
+    const scope = new Scope({ projectID: "123", domainID: "456" });
+    const resource = {
+      name: "testResource",
+      quota: 500,
+      capacity: 0,
+      totalCommitments: 10,
+      usagePerCommitted: 5,
+      usagePerQuota: 0,
+      per_az: [["az1", { projects_usage: 10 }]],
+    };
+    resource.per_az.commitmentSum = 10;
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
+            {children}
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+    const { result } = await waitFor(() => {
+      return renderHook(
+        () => ({
+          globalStoreActions: globalStoreActions(),
+          clusterStoreActions: clusterStoreActions(),
+          domainStoreActions: domainStoreActions(),
+          commitmentStore: createCommitmentStore(),
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+
+    const selectedAZ = screen.getByTestId("tab/az1");
+    expect(selectedAZ).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/src/components/project/ProjectQuotaDetails.js
+++ b/src/components/project/ProjectQuotaDetails.js
@@ -40,7 +40,7 @@ const ProjectQuotaDetails = (props) => {
     <DataGridRow>
       <DataGridCell>
         <Stack direction={"vertical"} className="w-full">
-          <div className="truncate">{scope?.isCluster() ? metadata.fullName : projectName}</div>
+          <div className="truncate">{scope.isCluster() ? metadata.fullName : projectName}</div>
           <div className="text-xs truncate">{projectID}</div>
         </Stack>
       </DataGridCell>

--- a/src/hooks/useResetCommitment.js
+++ b/src/hooks/useResetCommitment.js
@@ -18,7 +18,6 @@ import { createCommitmentStoreActions } from "../components/StoreProvider";
 import { initialCommitmentObject } from "../lib/constants";
 
 const useResetCommitment = () => {
-  const { setCurrentAZ } = createCommitmentStoreActions();
   const { setIsCommitting } = createCommitmentStoreActions();
   const { setCommitment } = createCommitmentStoreActions();
   const { setTransferredCommitment } = createCommitmentStoreActions();
@@ -31,8 +30,7 @@ const useResetCommitment = () => {
   const { setUpdateDurationCommitment } = createCommitmentStoreActions();
 
   // Handle closure of edit panel.
-  function resetCommitment(az) {
-    setCurrentAZ(az[0]);
+  function resetCommitment() {
     resetURLChangeState();
   }
 

--- a/src/lib/scope.js
+++ b/src/lib/scope.js
@@ -44,8 +44,8 @@ export const getCerebroBaseURL = () => {
  */
 export class Scope {
   constructor(scopeData) {
-    this.domainID = scopeData.domainID;
-    this.projectID = scopeData.projectID;
+    this.domainID = scopeData?.domainID;
+    this.projectID = scopeData?.projectID;
   }
   appComponent() {
     if (this.projectID) return AppResourceContent;

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -16,6 +16,7 @@
 
 import { CEREBROKEY } from "../constants";
 import { unusedCommitments, uncommittedUsage } from "../../lib/utils";
+import { Scope } from "../scope";
 
 const limesStore = (set, get) => ({
   cluster: {
@@ -188,7 +189,7 @@ const limesStore = (set, get) => ({
     },
   },
   global: {
-    scope: null,
+    scope: new Scope(),
 
     actions: {
       setScope: (scope) => {


### PR DESCRIPTION
This PR updates the juno components to 2.34. 2.35 has bugs which should be avoided for now.
A few things break here, which is why the update was postponed:
* The Juno Panel immediately calls the unmount statement of a useEffect if it is wrapped by the StyleProvider component. 
* The MenuItem component is bugged and always acts like a static `<div>` if children are delivered. Regardless if it has a callBack listener.

The fixes for those changes are included here. The currentAZ state was transformed into a local state instead of a store variable, which nullfies the necessity to reset the state manually. 
This behavior will be extended to other store variables in the future.

The MenuItem now displays `Transferring` instead of `Transfer` if a commitment is currently in a transferring state. This is a workaround for the MenuItem change mentioned above. A future test will be implemented, I couldn't get the modal called via jest for now. However, a TODO to do so is added.