### PR TITLE
fix: publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   build-and-publish:
-    if: ${{ startsWith(github.head_ref, 'changeset-release/') }}
+    if: ${{ contains(github.head_ref, 'changeset-release') }}
     runs-on: [ubuntu-latest]
     env:
       ACTIONS_RUNNER_DEBUG: true


### PR DESCRIPTION
The previous implementation assumed that the changeset branch starts with `changeset-release` however, the organization will be added to the branch name, resulting in `sapcc/changeset-release`.
Therefore a contains check might be more appropriate to use here.