### PR TITLE
fix source branch ref

### DIFF
--- a/.changeset/fresh-socks-refuse.md
+++ b/.changeset/fresh-socks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+push workflows demand github.ref instead of head_ref

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   build-and-publish:
-    if: ${{ contains(github.head_ref, 'changeset-release') }}
+    if: ${{ contains(github.ref, 'changeset-release') }}
     runs-on: [ubuntu-latest]
     env:
       ACTIONS_RUNNER_DEBUG: true


### PR DESCRIPTION
github.head_ref is only available for on `pull_request` workflows, however, the publish workflow operates on `push`.