### PR TITLE
adjust publish workflow

### DIFF
--- a/.changeset/poor-phones-fix.md
+++ b/.changeset/poor-phones-fix.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+adjust publish workflow to trigger on true release updates

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,15 +1,16 @@
 name: package-release
 on:
-  push:
+  pull_request:
     branches:
       - main
+    types: [closed]
     paths:
       - package.json
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 jobs:
   build-and-publish:
-    if: ${{ contains(github.ref, 'changeset-release') }}
+    if: ${{ contains(github.head_ref, 'changeset-release') && github.event.pull_request.merged == true }}
     runs-on: [ubuntu-latest]
     env:
       ACTIONS_RUNNER_DEBUG: true


### PR DESCRIPTION
I had to look more closer into this and set up a test environment, because the previous attempts to limit the workflow were rather unsuccessful.
It turns out that the latest introduced `github.ref` check contains the value: `refs/pull/{mergeNr.}/merge` when the PR is closed, and `refs/heads/main` when it is merged.
The issue is that once a workflow triggers on a `push` it does not remain references to the source branch.

To solve that, the workflow now executes on a closed `pull_request`. With this event type we gain access to `github_head_ref` which I originally wanted, but is empty if the event type is alnything else.
To now limit the execution to the changeset branch, we check for merge event from  `changeset-release` branches.
Additionally the limitation to `paths: package.json` is already included, which I overlooked originally.

This leaves us with a more desired state, that dependency bumps or manual changes that also modify the package.json, but not the version, skip the workflow.
For everything else, changesets get created, which do not modify the package version and therefore don't spam the action log with skipped entires.