### PR TITLE
[feat] Add renewal tab on project level

### DIFF
--- a/.changeset/honest-lemons-dig.md
+++ b/.changeset/honest-lemons-dig.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": minor
+---
+
+Add commitment renewal

--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -134,7 +134,7 @@ const build = async () => {
               let content;
               // handle scss, convert to css
               if (args.path.endsWith(".scss")) {
-                const result = sass.renderSync({ file: args.path });
+                const result = sass.compile(args.path);
                 content = result.css;
               } else {
                 // read file content

--- a/src/components/commitment/Modals/BaseComponents/useConfirmInput.js
+++ b/src/components/commitment/Modals/BaseComponents/useConfirmInput.js
@@ -66,7 +66,6 @@ const ConfirmInput = (props) => {
             data-testid="confirmInput"
             width="auto"
             disabled={disabled}
-            autoFocus
             errortext={invalidInput && "Please enter the highlighted term above."}
             onChange={(e) => onInput(e)}
           />

--- a/src/components/commitment/Modals/RenewModal.js
+++ b/src/components/commitment/Modals/RenewModal.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import BaseFooter from "./BaseComponents/BaseFooter";
+import useConfirmInput from "./BaseComponents/useConfirmInput";
+import { Modal, DataGrid, DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components";
+import { Unit, valueWithUnit } from "../../../lib/unit";
+import { formatTimeISO8160 } from "../../../lib/utils";
+
+const label = "font-semibold";
+
+const RenewModal = (props) => {
+  const { commitments = [] } = props;
+  const isSingleCommitment = commitments.length == 1;
+  const unit = isSingleCommitment && new Unit(commitments[0].unit);
+  const { action, title, subText, onModalClose } = props;
+  const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
+    confirmationText: subText,
+  });
+
+  function onRenew() {
+    action(commitments);
+  }
+
+  return (
+    <Modal
+      className="max-h-full"
+      title={title}
+      open={true}
+      modalFooter={
+        <BaseFooter onModalClose={onModalClose} guardFns={[checkInput]} actionFn={onRenew} variant={"primary"} />
+      }
+      onCancel={() => {
+        onModalClose();
+      }}
+    >
+      <div className={label}>
+        About to renew: {commitments.length} {isSingleCommitment ? "commitment" : "commitments"}
+      </div>
+      {isSingleCommitment && (
+        <DataGrid columns={2} columnMaxSize="1fr">
+          <DataGridRow>
+            <DataGridCell className={label}>Resource:</DataGridCell>
+            <DataGridCell>{commitments[0].resource_name}</DataGridCell>
+          </DataGridRow>
+          <DataGridRow>
+            <DataGridCell className={label}>Amount:</DataGridCell>
+            <DataGridCell>{valueWithUnit(commitments[0].amount, unit)}</DataGridCell>
+          </DataGridRow>
+          <DataGridRow>
+            <DataGridCell className={label}>Expires At:</DataGridCell>
+            <DataGridCell>{formatTimeISO8160(commitments[0].expires_at)}</DataGridCell>
+          </DataGridRow>
+        </DataGrid>
+      )}
+      <ConfirmInput subText={subText} {...inputProps} />
+    </Modal>
+  );
+};
+
+export default RenewModal;

--- a/src/components/commitment/Modals/RenewModal.js
+++ b/src/components/commitment/Modals/RenewModal.js
@@ -55,7 +55,7 @@ const RenewModal = (props) => {
         <DataGrid columns={2} columnMaxSize="1fr">
           <DataGridRow>
             <DataGridCell className={label}>Resource:</DataGridCell>
-            <DataGridCell>{commitments[0].resource_name}</DataGridCell>
+            <DataGridCell data-testid={"renewResource"}>{commitments[0].resource_name}</DataGridCell>
           </DataGridRow>
           <DataGridRow>
             <DataGridCell className={label}>Amount:</DataGridCell>

--- a/src/components/commitment/Operations/Actions.js
+++ b/src/components/commitment/Operations/Actions.js
@@ -25,8 +25,7 @@ import useUpdateDurationAction from "./useUpdateDurationAction";
 
 const Actions = (props) => {
   const { commitment = {}, resource = {} } = props;
-  const { confirmed_at: isConfirmed = false } = commitment;
-  const { isPlanned, isPending } = useCommitmentFilter();
+  const { getCommitmentLabel } = useCommitmentFilter();
   const [commitmentActions, setCommitmentActions] = React.useState([]);
 
   const hasTooltips = React.useMemo(() => {
@@ -49,22 +48,10 @@ const Actions = (props) => {
   useUpdateDurationAction({ commitment, resource, updateActions });
   useTransferAction({ commitment, updateActions });
 
-  function setCommitmentLabel() {
-    let label;
-    isConfirmed
-      ? (label = "Committed")
-      : isPending(commitment)
-        ? (label = "Pending")
-        : isPlanned(commitment)
-          ? (label = "Planned")
-          : (label = "");
-    return label;
-  }
-
   return (
     <Stack distribution="between">
       <Stack gap="1" alignment="center">
-        {setCommitmentLabel()}
+        {getCommitmentLabel(commitment)}
         {hasTooltips && (
           <CommitmentTooltip
             displayText={<Icon size="16" icon="info" />}

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -35,7 +35,7 @@ import { createCommitmentStoreActions } from "../StoreProvider";
 
 export const renewableInfoText = "No renewable commitments found for this project.";
 export const renewableInfoHint = [
-  "You will usually not need to check this page proactively.",
+  "You typically won't need to check this page proactively.",
   "We will send mail notifications when active commitments are about to expire.",
 ];
 export const inconsistentInfoText = "Resolve the state of the listed commitments first.";

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -55,6 +55,7 @@ const CommitmentRenewal = (props) => {
   const headCells = [
     { key: "Category", label: "Category" },
     { key: "resourceName", label: "Resource" },
+    { key: "availabilityZone", label: "AZ" },
     { key: "amount", label: "Amount" },
     { key: "duration", label: "Duration" },
     { key: "confirmedAt", label: "Confirmed at" },
@@ -89,6 +90,7 @@ const CommitmentRenewal = (props) => {
       <DataGridRow key={c.id}>
         <DataGridCell>{t(c.service_type)}</DataGridCell>
         <DataGridCell>{t(c.resource_name)}</DataGridCell>
+        <DataGridCell>{c.availability_zone}</DataGridCell>
         <DataGridCell>{valueWithUnit(c.amount, unit)}</DataGridCell>
         <DataGridCell>{c.duration}</DataGridCell>
         <DataGridCell>{formatTimeISO8160(c.confirmed_at)}</DataGridCell>

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -25,7 +25,6 @@ import {
   SelectOption,
   Stack,
   Message,
-  Toast,
 } from "@cloudoperators/juno-ui-components/index";
 import RenewModal from "../commitment/Modals/RenewModal";
 import { t, formatTimeISO8160 } from "../../lib/utils";
@@ -35,10 +34,10 @@ import { useMutation } from "@tanstack/react-query";
 import { createCommitmentStoreActions } from "../StoreProvider";
 
 export const renewableInfoText = "No renewable commitments found for this project.";
-export const inconsistentInfoText = "Resolve the listed inconsistencies first.";
+export const inconsistentInfoText = "Resolve the state of the listed commitments first.";
 export const inconsistentInfoHint = [
-  "This page can contain information about expiring commitments in an inconsistent state.",
-  "It is recommended to check this page if you receive a notification about expiring commitments.",
+  "You will usually not need to check this page proactively.",
+  "We will send mail notifications when active commitments are about to expire.",
 ];
 
 const CommitmentRenewal = (props) => {
@@ -135,16 +134,14 @@ const CommitmentRenewal = (props) => {
   return (
     <div>
       {toast && (
-        <Toast
-          text={<span className="whitespace-pre-line">{toast}</span>}
-          variant="error"
-          onDismiss={() => setToast(null)}
-        />
+        <Message variant="error" dismissible={true} onDismiss={() => setToast(null)}>
+          <span className="whitespace-pre-line">{toast}</span>
+        </Message>
       )}
       {hasRenewable ? (
         <div>
           {!hasInconsistencies && (
-            <Message data-testid="inconsistentInfoHint" className="mb-2">
+            <Message data-testid="inconsistentInfoHint" className="mb-2" dismissible={true}>
               {inconsistentInfoHint.map((hint, i) => (
                 <div key={i}>{hint}</div>
               ))}
@@ -188,14 +185,16 @@ const CommitmentRenewal = (props) => {
           </DataGrid>
         </div>
       ) : (
-        <Message className="mb-4 font-medium" variant="info">
+        <Message className="mb-4 font-medium" variant="info" dismissible={true}>
           <div>{renewableInfoText}</div>
           {hasInconsistencies && <div>{inconsistentInfoText}</div>}
         </Message>
       )}
       {hasInconsistencies && (
         <div>
-          <div className={categoryTitle}>Expiring commitments that were not confirmed and therefore cannot be renewed</div>
+          <div className={categoryTitle}>
+            Expiring commitments that were not confirmed and therefore cannot be renewed
+          </div>
           <DataGrid columns={inconsistencyHeadCells.length}>
             <DataGridRow>
               {inconsistencyHeadCells.map((headCell) => (

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -36,7 +36,7 @@ import { createCommitmentStoreActions } from "../StoreProvider";
 export const renewableInfoText = "No renewable commitments found for this project.";
 export const renewableInfoHint = [
   "You typically won't need to check this page proactively.",
-  "We will send mail notifications when active commitments are about to expire.",
+  "We will send mail notifications when your active commitments are nearing expiration.",
 ];
 export const inconsistentInfoText = "Resolve the state of the listed commitments first.";
 

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -24,6 +24,7 @@ import {
   Select,
   SelectOption,
   Stack,
+  Message,
   Toast,
 } from "@cloudoperators/juno-ui-components/index";
 import RenewModal from "../commitment/Modals/RenewModal";
@@ -35,6 +36,8 @@ import { createCommitmentStoreActions } from "../StoreProvider";
 
 const CommitmentRenewal = (props) => {
   const { renewable = [], inconsistent = [] } = props;
+  const hasRenewable = renewable.length > 0;
+  const hasInconsistencies = inconsistent.length > 0;
   const [displayedRenewables, setDisplayedRenewables] = React.useState(renewable);
   const [showModal, setShowModal] = React.useState(false);
   const [toast, setToast] = React.useState(null);
@@ -143,50 +146,62 @@ const CommitmentRenewal = (props) => {
   return (
     <div>
       {toast && <Toast className={"pb-0"} text={toast} variant="error" onDismiss={() => setToast(null)} />}
-      <div className={categoryTitle}>Renewable Commitments</div>
-      <Stack className="mb-4" alignment="center" gap="2">
-        <div className="whitespace-nowrap">Renew commitments for:</div>
-        <Select
-          className="w-48"
-          width="auto"
-          defaultValue={selectedCategory.current}
-          onValueChange={(value) => onRenewSelectionChange(value)}
-        >
-          {Object.keys(renewablePerService).map((renewable) => (
-            <SelectOption key={renewable} value={renewable} label={t(renewable)} />
-          ))}
-        </Select>
-        <Button
-          className="w-10"
-          icon="openInNew"
-          variant="primary"
-          onClick={() => {
-            setShowModal(true);
-            commitmentsForModal.current = renewablePerService[selectedCategory.current];
-          }}
-        />
-      </Stack>
-      <DataGrid columns={renewableHeadCells.length} className={"mb-10"}>
-        <DataGridRow>
-          {renewableHeadCells.map((headCell) => (
-            <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
-          ))}
-        </DataGridRow>
-        {displayedRenewables.map((c) => {
-          return getTableData(c, true);
-        })}
-      </DataGrid>
-      <div className={categoryTitle}>Inconsistencies</div>
-      <DataGrid columns={inconsistencyHeadCells.length}>
-        <DataGridRow>
-          {inconsistencyHeadCells.map((headCell) => (
-            <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
-          ))}
-        </DataGridRow>
-        {inconsistent.map((c) => {
-          return getTableData(c, false);
-        })}
-      </DataGrid>
+      {hasRenewable ? (
+        <div>
+          <div className={categoryTitle}>Renewable Commitments</div>
+          <Stack className="mb-4" alignment="center" gap="2">
+            <div className="whitespace-nowrap">Renew commitments for:</div>
+            <Select
+              className="w-48"
+              width="auto"
+              defaultValue={selectedCategory.current}
+              onValueChange={(value) => onRenewSelectionChange(value)}
+            >
+              {Object.keys(renewablePerService).map((renewable) => (
+                <SelectOption key={renewable} value={renewable} label={t(renewable)} />
+              ))}
+            </Select>
+            <Button
+              className="w-10"
+              icon="openInNew"
+              variant="primary"
+              onClick={() => {
+                setShowModal(true);
+                commitmentsForModal.current = renewablePerService[selectedCategory.current];
+              }}
+            />
+          </Stack>
+          <DataGrid columns={renewableHeadCells.length} className={"mb-10"}>
+            <DataGridRow>
+              {renewableHeadCells.map((headCell) => (
+                <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
+              ))}
+            </DataGridRow>
+            {displayedRenewables.map((c) => {
+              return getTableData(c, true);
+            })}
+          </DataGrid>
+        </div>
+      ) : (
+        <Message className="mb-4 font-medium" variant="info">
+          No expiring commitments found for this project.
+        </Message>
+      )}
+      {hasInconsistencies && (
+        <div>
+          <div className={categoryTitle}>Inconsistencies</div>
+          <DataGrid columns={inconsistencyHeadCells.length}>
+            <DataGridRow>
+              {inconsistencyHeadCells.map((headCell) => (
+                <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
+              ))}
+            </DataGridRow>
+            {inconsistent.map((c) => {
+              return getTableData(c, false);
+            })}
+          </DataGrid>
+        </div>
+      )}
       {showModal && (
         <RenewModal
           title="Renew Commitments"

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -123,7 +123,7 @@ const CommitmentRenewal = (props) => {
   }
 
   function onRenew(commitments) {
-    let payload = {commitment_ids: []};
+    let payload = { commitment_ids: [] };
     commitments.forEach((c) => payload.commitment_ids.push(c.id));
     commitmentRenew.mutate(
       {
@@ -142,9 +142,7 @@ const CommitmentRenewal = (props) => {
 
   return (
     <div>
-      {toast && (
-        <Toast className={"pb-0"} text={toast} variant="error" onDismiss={() => setToast(null)} />
-      )}
+      {toast && <Toast className={"pb-0"} text={toast} variant="error" onDismiss={() => setToast(null)} />}
       <div className={categoryTitle}>Renewable Commitments</div>
       <Stack className="mb-4" alignment="center" gap="2">
         <div className="whitespace-nowrap">Renew commitments for:</div>

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -34,8 +34,12 @@ import { categoryTitle } from "../paygAvailability/stylescss";
 import { useMutation } from "@tanstack/react-query";
 import { createCommitmentStoreActions } from "../StoreProvider";
 
-export const inconsistentInfoText = "Resolve the listed inconsistencies first.";
 export const renewableInfoText = "No renewable commitments found for this project.";
+export const inconsistentInfoText = "Resolve the listed inconsistencies first.";
+export const inconsistentInfoHint = [
+  "This page can contain information about expiring commitments in an inconsistent state.",
+  "It is recommended to check this page if you receive information about expiring commitments.",
+];
 
 const CommitmentRenewal = (props) => {
   const { renewable = [], inconsistent = [] } = props;
@@ -154,6 +158,13 @@ const CommitmentRenewal = (props) => {
       {toast && <Toast className={"pb-0"} text={toast} variant="error" onDismiss={() => setToast(null)} />}
       {hasRenewable ? (
         <div>
+          {!hasInconsistencies && (
+            <Message data-testid="inconsistentInfoHint" className="mb-2">
+              {inconsistentInfoHint.map((hint, i) => (
+                <div key={i}>{hint}</div>
+              ))}
+            </Message>
+          )}
           <div className={categoryTitle}>Renewable Commitments</div>
           <Stack className="mb-4" alignment="center" gap="2">
             <div className="whitespace-nowrap">Renew commitments for:</div>

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import {
+  Button,
+  DataGrid,
+  DataGridRow,
+  DataGridCell,
+  DataGridHeadCell,
+  Select,
+  SelectOption,
+  Stack,
+  Toast,
+} from "@cloudoperators/juno-ui-components/index";
+import RenewModal from "../commitment/Modals/RenewModal";
+import { t, formatTimeISO8160 } from "../../lib/utils";
+import { Unit, valueWithUnit } from "../../lib/unit";
+import { categoryTitle } from "../paygAvailability/stylescss";
+import { useMutation } from "@tanstack/react-query";
+import { createCommitmentStoreActions } from "../StoreProvider";
+
+const CommitmentRenewal = (props) => {
+  const { renewable = [], inconsistent = [] } = props;
+  const [displayedRenewables, setDisplayedRenewables] = React.useState(renewable);
+  const [showModal, setShowModal] = React.useState(false);
+  const [toast, setToast] = React.useState(null);
+  const allCategoriesLabel = "All Categories";
+  const selectedCategory = React.useRef(allCategoriesLabel);
+  const commitmentsForModal = React.useRef();
+  const commitmentRenew = useMutation({
+    mutationKey: ["renewCommitment"],
+  });
+  const { setRefetchCommitmentAPI } = createCommitmentStoreActions();
+  const headCells = [
+    {
+      key: "Category",
+      label: "Category",
+    },
+    {
+      key: "resourceName",
+      label: "Resource",
+    },
+    {
+      key: "amount",
+      label: "Amount",
+    },
+    {
+      key: "duration",
+      label: "Duration",
+    },
+    {
+      key: "confirmedAt",
+      label: "Confirmed at",
+    },
+    {
+      key: "expiresAt",
+      label: "Expires at",
+    },
+  ];
+  let renewableHeadCells = [...headCells];
+  renewableHeadCells.push({ key: "renew", label: "Renew" });
+  let inconsistencyHeadCells = [...headCells];
+  inconsistencyHeadCells.push({ key: "reason", label: "Reason" });
+
+  const renewablePerService = React.useMemo(() => {
+    let result = renewable.reduce((map, c) => {
+      if (!map[c.service_type]) {
+        map[c.service_type] = [];
+      }
+      map[c.service_type].push(c);
+      return map;
+    }, {});
+    result[allCategoriesLabel] = renewable;
+    return result;
+  }, [renewable]);
+
+  function onRenewSelectionChange(value) {
+    selectedCategory.current = value;
+    setDisplayedRenewables(renewablePerService[value]);
+  }
+
+  function getTableData(c, showRenewable) {
+    const unit = new Unit(c.unit);
+    return (
+      <DataGridRow key={c.id}>
+        <DataGridCell>{t(c.service_type)}</DataGridCell>
+        <DataGridCell>{t(c.resource_name)}</DataGridCell>
+        <DataGridCell>{valueWithUnit(c.amount, unit)}</DataGridCell>
+        <DataGridCell>{c.duration}</DataGridCell>
+        <DataGridCell>{formatTimeISO8160(c.confirmed_at)}</DataGridCell>
+        <DataGridCell>{formatTimeISO8160(c.expires_at)}</DataGridCell>
+        {showRenewable && (
+          <DataGridCell>
+            <Button
+              className="w-10"
+              icon="openInNew"
+              size="small"
+              variant="primary"
+              onClick={() => {
+                setShowModal(true);
+                commitmentsForModal.current = [c];
+              }}
+            />
+          </DataGridCell>
+        )}
+        {!showRenewable && <DataGridCell>{c.reason}</DataGridCell>}
+      </DataGridRow>
+    );
+  }
+
+  function onRenew(commitments) {
+    let payload = {commitment_ids: []};
+    commitments.forEach((c) => payload.commitment_ids.push(c.id));
+    commitmentRenew.mutate(
+      {
+        payload: payload,
+      },
+      {
+        onSuccess: () => {
+          setRefetchCommitmentAPI(true);
+        },
+        onError: (error) => {
+          setToast(error.toString());
+        },
+      }
+    );
+  }
+
+  return (
+    <div>
+      {toast && (
+        <Toast className={"pb-0"} text={toast} variant="error" onDismiss={() => setToast(null)} />
+      )}
+      <div className={categoryTitle}>Renewable Commitments</div>
+      <Stack className="mb-4" alignment="center" gap="2">
+        <div className="whitespace-nowrap">Renew commitments for:</div>
+        <Select
+          className="w-48"
+          width="auto"
+          defaultValue={selectedCategory.current}
+          onValueChange={(value) => onRenewSelectionChange(value)}
+        >
+          {Object.keys(renewablePerService).map((renewable) => (
+            <SelectOption key={renewable} value={renewable} label={t(renewable)} />
+          ))}
+        </Select>
+        <Button
+          className="w-10"
+          icon="openInNew"
+          variant="primary"
+          onClick={() => {
+            setShowModal(true);
+            commitmentsForModal.current = renewablePerService[selectedCategory.current];
+          }}
+        />
+      </Stack>
+      <DataGrid columns={renewableHeadCells.length} className={"mb-10"}>
+        <DataGridRow>
+          {renewableHeadCells.map((headCell) => (
+            <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
+          ))}
+        </DataGridRow>
+        {displayedRenewables.map((c) => {
+          return getTableData(c, true);
+        })}
+      </DataGrid>
+      <div className={categoryTitle}>Inconsistencies</div>
+      <DataGrid columns={inconsistencyHeadCells.length}>
+        <DataGridRow>
+          {inconsistencyHeadCells.map((headCell) => (
+            <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
+          ))}
+        </DataGridRow>
+        {inconsistent.map((c) => {
+          return getTableData(c, false);
+        })}
+      </DataGrid>
+      {showModal && (
+        <RenewModal
+          title="Renew Commitments"
+          subText="renew"
+          action={onRenew}
+          commitments={commitmentsForModal.current}
+          onModalClose={() => setShowModal(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default CommitmentRenewal;

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -35,8 +35,8 @@ import { createCommitmentStoreActions } from "../StoreProvider";
 
 export const renewableInfoText = "No renewable commitments found for this project.";
 export const renewableInfoHint = [
-  "You typically won't need to check this page proactively.",
-  "We will send mail notifications when your active commitments are nearing expiration.",
+  "You will usually not need to check this page proactively.",
+  "We will send mail notifications when active commitments are about to expire.",
 ];
 export const inconsistentInfoText = "Resolve the state of the listed commitments first.";
 

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -38,7 +38,7 @@ export const renewableInfoText = "No renewable commitments found for this projec
 export const inconsistentInfoText = "Resolve the listed inconsistencies first.";
 export const inconsistentInfoHint = [
   "This page can contain information about expiring commitments in an inconsistent state.",
-  "It is recommended to check this page if you receive information about expiring commitments.",
+  "It is recommended to check this page if you receive a notification about expiring commitments.",
 ];
 
 const CommitmentRenewal = (props) => {

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -99,6 +99,7 @@ const CommitmentRenewal = (props) => {
           <DataGridCell>
             <Button
               data-testid={"renew" + c.id}
+              title="Renew Commitment"
               className="w-10"
               icon="openInNew"
               size="small"
@@ -165,6 +166,7 @@ const CommitmentRenewal = (props) => {
             </Select>
             <Button
               data-testid="renewMultiple"
+              title="Renew all"
               className="w-10"
               icon="openInNew"
               variant="primary"
@@ -193,7 +195,7 @@ const CommitmentRenewal = (props) => {
       )}
       {hasInconsistencies && (
         <div>
-          <div className={categoryTitle}>Inconsistencies</div>
+          <div className={categoryTitle}>Expiring commitments that were not confirmed and therefore cannot be renewed</div>
           <DataGrid columns={inconsistencyHeadCells.length}>
             <DataGridRow>
               {inconsistencyHeadCells.map((headCell) => (

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -34,6 +34,9 @@ import { categoryTitle } from "../paygAvailability/stylescss";
 import { useMutation } from "@tanstack/react-query";
 import { createCommitmentStoreActions } from "../StoreProvider";
 
+export const inconsistentInfoText = "Resolve the listed inconsistencies first.";
+export const renewableInfoText = "No renewable commitments found for this project.";
+
 const CommitmentRenewal = (props) => {
   const { renewable = [], inconsistent = [] } = props;
   const hasRenewable = renewable.length > 0;
@@ -80,14 +83,16 @@ const CommitmentRenewal = (props) => {
   inconsistencyHeadCells.push({ key: "reason", label: "Reason" });
 
   const renewablePerService = React.useMemo(() => {
-    let result = renewable.reduce((map, c) => {
-      if (!map[c.service_type]) {
-        map[c.service_type] = [];
+    const renewableResult = renewable.reduce((obj, c) => {
+      if (!obj[c.service_type]) {
+        obj[c.service_type] = [];
       }
-      map[c.service_type].push(c);
-      return map;
+      obj[c.service_type].push(c);
+      return obj;
     }, {});
-    result[allCategoriesLabel] = renewable;
+    let allCategories = {};
+    allCategories[allCategoriesLabel] = renewable;
+    const result = Object.assign(allCategories, renewableResult);
     return result;
   }, [renewable]);
 
@@ -109,6 +114,7 @@ const CommitmentRenewal = (props) => {
         {showRenewable && (
           <DataGridCell>
             <Button
+              data-testid={"renew" + c.id}
               className="w-10"
               icon="openInNew"
               size="small"
@@ -152,16 +158,18 @@ const CommitmentRenewal = (props) => {
           <Stack className="mb-4" alignment="center" gap="2">
             <div className="whitespace-nowrap">Renew commitments for:</div>
             <Select
+              data-testid={"renewSelect"}
               className="w-48"
               width="auto"
               defaultValue={selectedCategory.current}
               onValueChange={(value) => onRenewSelectionChange(value)}
             >
               {Object.keys(renewablePerService).map((renewable) => (
-                <SelectOption key={renewable} value={renewable} label={t(renewable)} />
+                <SelectOption data-testid={renewable} key={renewable} value={renewable} label={t(renewable)} />
               ))}
             </Select>
             <Button
+              data-testid="renewMultiple"
               className="w-10"
               icon="openInNew"
               variant="primary"
@@ -184,7 +192,8 @@ const CommitmentRenewal = (props) => {
         </div>
       ) : (
         <Message className="mb-4 font-medium" variant="info">
-          No expiring commitments found for this project.
+          <div>{renewableInfoText}</div>
+          {hasInconsistencies && <div>{inconsistentInfoText}</div>}
         </Message>
       )}
       {hasInconsistencies && (

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -34,11 +34,11 @@ import { useMutation } from "@tanstack/react-query";
 import { createCommitmentStoreActions } from "../StoreProvider";
 
 export const renewableInfoText = "No renewable commitments found for this project.";
-export const inconsistentInfoText = "Resolve the state of the listed commitments first.";
-export const inconsistentInfoHint = [
+export const renewableInfoHint = [
   "You will usually not need to check this page proactively.",
   "We will send mail notifications when active commitments are about to expire.",
 ];
+export const inconsistentInfoText = "Resolve the state of the listed commitments first.";
 
 const CommitmentRenewal = (props) => {
   const { renewable = [], inconsistent = [] } = props;
@@ -142,7 +142,7 @@ const CommitmentRenewal = (props) => {
         <div>
           {!hasInconsistencies && (
             <Message data-testid="inconsistentInfoHint" className="mb-2" dismissible={true}>
-              {inconsistentInfoHint.map((hint, i) => (
+              {renewableInfoHint.map((hint, i) => (
                 <div key={i}>{hint}</div>
               ))}
             </Message>
@@ -187,6 +187,9 @@ const CommitmentRenewal = (props) => {
       ) : (
         <Message className="mb-4 font-medium" variant="info" dismissible={true}>
           <div>{renewableInfoText}</div>
+          {renewableInfoHint.map((hint, i) => (
+            <div key={i}>{hint}</div>
+          ))}
           {hasInconsistencies && <div>{inconsistentInfoText}</div>}
         </Message>
       )}

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -63,6 +63,12 @@ const RenewalManager = () => {
     if (a.service_type > b.service_type) {
       return 1;
     }
+    if (a.expires_at < b.expires_at) {
+      return -1;
+    }
+    if (a.expires_at > b.expires_at) {
+      return 1;
+    }
     return 0;
   }
 

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -17,6 +17,7 @@
 import React from "react";
 import CommitmentRenewal from "./CommitmentRenewal";
 import moment from "moment";
+import { parseCommitmentDuration } from "../../lib/parseCommitmentDurations";
 import { projectStore } from "../StoreProvider";
 import useCommitmentFilter from "../../hooks/useCommitmentFilter";
 
@@ -30,17 +31,13 @@ const RenewalManager = () => {
     let renewableCommitments = commitments.filter(
       (c) =>
         !c.was_extended &&
+        parseCommitmentDuration(c.duration) >= parseCommitmentDuration("1 year") &&
         moment(now).isAfter(moment(c.expires_at).subtract(3, "months")) &&
         moment(now).isBefore(moment(c.expires_at))
     );
 
     let inconsistentCommitments = [];
     renewableCommitments.forEach((c) => {
-      if (c.transfer_status) {
-        c.reason = "in transfer";
-        inconsistentCommitments.push(c);
-        return;
-      }
       if (!isActive(c)) {
         c.reason = getCommitmentLabel(c);
         inconsistentCommitments.push(c);

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import CommitmentRenewal from "./CommitmentRenewal";
+import moment from "moment";
+import { projectStore } from "../StoreProvider";
+import useCommitmentFilter from "../../hooks/useCommitmentFilter";
+
+// RenewalManager fetches renwable commitments for the current scope.
+// Currently only available at project level.
+const RenewalManager = () => {
+  const { commitments } = projectStore();
+  const { isActive, getCommitmentLabel } = useCommitmentFilter();
+  const now = moment().utc().unix();
+
+  const [renewableCommitments, inconsistentCommitments] = React.useMemo(() => {
+    let renewableCommitments = commitments.filter(
+      (c) =>
+        moment(now).isAfter(moment(c.expires_at).subtract(3, "months")) && moment(now).isBefore(moment(c.expires_at))
+    );
+
+    let inconsistentCommitments = [];
+    renewableCommitments.forEach((c) => {
+      if (c.transfer_status) {
+        c.reason = "in transfer";
+        inconsistentCommitments.push(c);
+        return;
+      }
+      if (!isActive(c)) {
+        c.reason = getCommitmentLabel(c);
+        inconsistentCommitments.push(c);
+        return;
+      }
+    });
+    inconsistentCommitments.forEach((c) => {
+      const index = renewableCommitments.indexOf(c);
+      renewableCommitments.splice(index, 1);
+    });
+
+    return [renewableCommitments, inconsistentCommitments];
+  }, [commitments]);
+
+  return <CommitmentRenewal renewable={renewableCommitments} inconsistent={inconsistentCommitments} />;
+};
+
+export default RenewalManager;

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -19,6 +19,7 @@ import CommitmentRenewal from "./CommitmentRenewal";
 import moment from "moment";
 import { parseCommitmentDuration } from "../../lib/parseCommitmentDurations";
 import { projectStore } from "../StoreProvider";
+import { t } from "../../lib/utils";
 import useCommitmentFilter from "../../hooks/useCommitmentFilter";
 
 // RenewalManager fetches renwable commitments for the current scope.
@@ -55,10 +56,10 @@ const RenewalManager = () => {
   }, [commitments]);
 
   function compareCommitmentsByCategory(a, b) {
-    if (a.service_type < b.service_type) {
+    if (t(a.service_type) < t(b.service_type)) {
       return -1;
     }
-    if (a.service_type > b.service_type) {
+    if (t(a.service_type) > t(b.service_type)) {
       return 1;
     }
     if (a.expires_at < b.expires_at) {

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -32,7 +32,7 @@ const RenewalManager = () => {
     if (!commitments) return [[], []];
     let renewableCommitments = commitments.filter(
       (c) =>
-        !c.was_extended &&
+        !c.was_renewed &&
         parseCommitmentDuration(c.duration) >= parseCommitmentDuration("1 year") &&
         now.isAfter(moment.unix(c.expires_at).subtract(3, "months")) &&
         now.isBefore(moment.unix(c.expires_at))

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -26,7 +26,6 @@ const RenewalManager = () => {
   const { commitments } = projectStore();
   const { isActive, getCommitmentLabel } = useCommitmentFilter();
   const now = moment().utc().unix();
-
   const [renewableCommitments, inconsistentCommitments] = React.useMemo(() => {
     let renewableCommitments = commitments.filter(
       (c) =>

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -29,7 +29,9 @@ const RenewalManager = () => {
   const [renewableCommitments, inconsistentCommitments] = React.useMemo(() => {
     let renewableCommitments = commitments.filter(
       (c) =>
-        moment(now).isAfter(moment(c.expires_at).subtract(3, "months")) && moment(now).isBefore(moment(c.expires_at))
+        !c.was_extended &&
+        moment(now).isAfter(moment(c.expires_at).subtract(3, "months")) &&
+        moment(now).isBefore(moment(c.expires_at))
     );
 
     let inconsistentCommitments = [];

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -51,9 +51,20 @@ const RenewalManager = () => {
       const index = renewableCommitments.indexOf(c);
       renewableCommitments.splice(index, 1);
     });
-
+    renewableCommitments = renewableCommitments.sort(compareCommitmentsByCategory);
+    inconsistentCommitments = inconsistentCommitments.sort(compareCommitmentsByCategory);
     return [renewableCommitments, inconsistentCommitments];
   }, [commitments]);
+
+  function compareCommitmentsByCategory(a, b) {
+    if (a.service_type < b.service_type) {
+      return -1;
+    }
+    if (a.service_type > b.service_type) {
+      return 1;
+    }
+    return 0;
+  }
 
   return <CommitmentRenewal renewable={renewableCommitments} inconsistent={inconsistentCommitments} />;
 };

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -26,14 +26,15 @@ import useCommitmentFilter from "../../hooks/useCommitmentFilter";
 const RenewalManager = () => {
   const { commitments } = projectStore();
   const { isActive, getCommitmentLabel } = useCommitmentFilter();
-  const now = moment().utc().unix();
+  const now = moment().utc();
   const [renewableCommitments, inconsistentCommitments] = React.useMemo(() => {
+    if (!commitments) return [[], []];
     let renewableCommitments = commitments.filter(
       (c) =>
         !c.was_extended &&
         parseCommitmentDuration(c.duration) >= parseCommitmentDuration("1 year") &&
-        moment(now).isAfter(moment(c.expires_at).subtract(3, "months")) &&
-        moment(now).isBefore(moment(c.expires_at))
+        now.isAfter(moment.unix(c.expires_at).subtract(3, "months")) &&
+        now.isBefore(moment.unix(c.expires_at))
     );
 
     let inconsistentCommitments = [];

--- a/src/components/commitmentRenewal/renewal.test.js
+++ b/src/components/commitmentRenewal/renewal.test.js
@@ -66,7 +66,7 @@ describe("Renewal Manger", () => {
         unit: "MiB",
         duration: "1 year",
         confirm_by: now,
-        expires_at: expireOutsideTimeFrame,
+        expires_at: expireWithinTimeframe,
       },
     ];
     const wrapper = ({ children }) => (
@@ -92,8 +92,8 @@ describe("Renewal Manger", () => {
     });
     await waitFor(() => {
       expect(screen.queryByText("resource_1")).toBeInTheDocument();
-      expect(screen.queryByText("resource_3")).not.toBeInTheDocument();
-      expect(screen.queryByText(inconsistentInfoText)).toBeInTheDocument();
+      expect(screen.queryByText("resource_2")).not.toBeInTheDocument();
+      expect(screen.queryByText("resource_3")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/commitmentRenewal/renewal.test.js
+++ b/src/components/commitmentRenewal/renewal.test.js
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import CommitmentRenewal from "./CommitmentRenewal";
+import moment from "moment";
+import StoreProvider, { createCommitmentStoreActions } from "../StoreProvider";
+import { PortalProvider } from "@cloudoperators/juno-ui-components";
+import { fireEvent, renderHook, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { inconsistentInfoText, renewableInfoText } from "./CommitmentRenewal";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 0,
+    },
+  },
+});
+queryClient.setQueryDefaults(["renewCommitment"], {
+  queryFn: () => {
+    return;
+  },
+});
+
+describe("Commitment renewal tests", () => {
+  test("Expect renewable and inconsistent commitments", async () => {
+    const now = moment().utc();
+    const expire = now.add(2, "months").unix();
+    const renewableCommitmnets = [
+      {
+        id: 1,
+        service_type: "service_1",
+        resource_name: "resource_1",
+        availability_zone: "az_1",
+        amount: 1,
+        duration: "1 year",
+        expires_at: expire,
+      },
+      {
+        id: 2,
+        service_type: "service_2",
+        resource_name: "resource_2",
+        availability_zone: "az_2",
+        amount: 1024,
+        unit: "MiB",
+        duration: "1 year",
+        expires_at: expire,
+      },
+    ];
+    const inconsistentCommitments = [
+      {
+        id: 3,
+        service_type: "service_3",
+        resource_name: "resource_3",
+        availability_zone: "az_1",
+        amount: 3,
+        duration: "1 year",
+        transfer_status: "unlisted",
+        reason: "in transfer",
+        expires_at: expire,
+      },
+      {
+        id: 4,
+        service_type: "service_4",
+        resource_name: "resource_4",
+        availability_zone: "az_1",
+        amount: 4,
+        duration: "1 year",
+        reason: "pending",
+        confirm_by: now.unix(),
+      },
+    ];
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <CommitmentRenewal renewable={renewableCommitmnets} inconsistent={inconsistentCommitments} />
+            {children}
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+    await waitFor(() => {
+      return renderHook(
+        () => ({
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+    const renewCommitmentBtn1 = screen.getByTestId("renew1");
+    const renewCommitmentBtn2 = screen.getByTestId("renew2");
+
+    // check modal of the first commitment
+    fireEvent.click(renewCommitmentBtn1);
+    const cancelModal1 = screen.getByTestId("modalCancel");
+    const modalContent1 = screen.getByTestId("renewResource");
+    expect(modalContent1.textContent).toEqual("resource_1");
+    fireEvent.click(cancelModal1);
+
+    // check modal of the second commitment
+    fireEvent.click(renewCommitmentBtn2);
+    const cancelModal2 = screen.getByTestId("modalCancel");
+    const modalContent2 = screen.getByTestId("renewResource");
+    expect(modalContent2.textContent).toEqual("resource_2");
+    fireEvent.click(cancelModal2);
+
+    // there should be no renewal for inconsistencies
+    expect(screen.queryByTestId("renew3")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("renew4")).not.toBeInTheDocument();
+    // but their values should be visible
+    expect(screen.queryByText("resource_3")).toBeInTheDocument();
+    expect(screen.queryByText("resource_4")).toBeInTheDocument();
+
+    // renew all applicable commitments (ID: 1 and 2)
+    const renewMultipleBtn = screen.getByTestId("renewMultiple");
+    fireEvent.click(renewMultipleBtn);
+    const cancelModal3 = screen.getByTestId("modalCancel");
+    expect(screen.getByText("About to renew: 2 commitments")).toBeInTheDocument();
+    fireEvent.click(cancelModal3);
+
+    // filter for a category
+    const renewSel = screen.getByTestId("renewSelect");
+    fireEvent.click(renewSel);
+    const renewOpt = screen.getByTestId("service_2");
+    // now service_1 should be filtered out
+    fireEvent.click(renewOpt);
+    await waitFor(() => {
+      expect(screen.queryByTestId("renew1")).not.toBeInTheDocument();
+    });
+    // and renew all categories displays one commitment
+    const renewMultipleBtn2 = screen.getByTestId("renewMultiple");
+    fireEvent.click(renewMultipleBtn2);
+    const cancelModal4 = screen.getByTestId("modalCancel");
+    expect(screen.getByText("About to renew: 1 commitment")).toBeInTheDocument();
+    fireEvent.click(cancelModal4);
+  });
+
+  test("Inconistencies but no renewables", async() => {
+    const now = moment().utc();
+    const expire = now.add(2, "months").unix();
+    const inconsistentCommitments = [
+      {
+        id: 3,
+        service_type: "service_3",
+        resource_name: "resource_3",
+        availability_zone: "az_1",
+        amount: 3,
+        duration: "1 year",
+        transfer_status: "unlisted",
+        reason: "in transfer",
+        expires_at: expire,
+      },
+      {
+        id: 4,
+        service_type: "service_4",
+        resource_name: "resource_4",
+        availability_zone: "az_1",
+        amount: 4,
+        duration: "1 year",
+        reason: "pending",
+        confirm_by: now.unix(),
+      },
+    ];
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <CommitmentRenewal inconsistent={inconsistentCommitments} />
+            {children}
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+    await waitFor(() => {
+      return renderHook(
+        () => ({
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+    expect(screen.getByText(renewableInfoText)).toBeInTheDocument();
+    expect(screen.getByText(inconsistentInfoText)).toBeInTheDocument();
+  });
+});

--- a/src/components/commitmentRenewal/renewal.test.js
+++ b/src/components/commitmentRenewal/renewal.test.js
@@ -198,4 +198,50 @@ describe("Commitment renewal tests", () => {
     expect(screen.getByText(renewableInfoText)).toBeInTheDocument();
     expect(screen.getByText(inconsistentInfoText)).toBeInTheDocument();
   });
+
+  test("Renewables but no inconistencies", async () => {
+    const now = moment().utc();
+    const expire = now.add(2, "months").unix();
+    const renewableCommitmnets = [
+      {
+        id: 1,
+        service_type: "service_1",
+        resource_name: "resource_1",
+        availability_zone: "az_1",
+        amount: 1,
+        duration: "1 year",
+        expires_at: expire,
+      },
+      {
+        id: 2,
+        service_type: "service_2",
+        resource_name: "resource_2",
+        availability_zone: "az_2",
+        amount: 1024,
+        unit: "MiB",
+        duration: "1 year",
+        expires_at: expire,
+      },
+    ];
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <CommitmentRenewal renewable={renewableCommitmnets} />
+            {children}
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+    await waitFor(() => {
+      return renderHook(
+        () => ({
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+
+    expect(screen.queryByTestId("inconsistentInfoHint")).toBeInTheDocument();
+  });
 });

--- a/src/components/commitmentRenewal/renewal.test.js
+++ b/src/components/commitmentRenewal/renewal.test.js
@@ -151,7 +151,7 @@ describe("Commitment renewal tests", () => {
     fireEvent.click(cancelModal4);
   });
 
-  test("Inconistencies but no renewables", async() => {
+  test("Inconistencies but no renewables", async () => {
     const now = moment().utc();
     const expire = now.add(2, "months").unix();
     const inconsistentCommitments = [

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -22,7 +22,7 @@ import { useParams, useNavigate, useLocation, Outlet } from "react-router";
 import { t, byUIString } from "../../lib/utils";
 import { ADVANCEDVIEW, CEREBROKEY, COMMITMENTRENWALKEY } from "../../lib/constants";
 import PAYGOverview from "../paygAvailability/bigVM/PAYGOverview";
-import CommitmentRenewal from "../commitmentRenewal/Overview";
+import RenewalManager from "../commitmentRenewal/RenewalManager";
 import { Tabs, Tab, TabList, TabPanel, Container, Button, Box } from "@cloudoperators/juno-ui-components";
 import { getScrapeTime } from "../../lib/getScrapeTime";
 
@@ -126,7 +126,7 @@ const Overview = (props) => {
   }
 
   function renderRenewal() {
-    return <CommitmentRenewal />;
+    return <RenewalManager />;
   }
 
   let currentTab;

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -20,7 +20,7 @@ import { globalStore, createCommitmentStore } from "../StoreProvider";
 import useResetCommitment from "../../hooks/useResetCommitment";
 import { useParams, useNavigate, useLocation, Outlet } from "react-router";
 import { t, byUIString } from "../../lib/utils";
-import { ADVANCEDVIEW, CEREBROKEY, COMMITMENTRENWALKEY } from "../../lib/constants";
+import { ADVANCEDVIEW, CEREBROKEY, COMMITMENTRENEWALKEY } from "../../lib/constants";
 import PAYGOverview from "../paygAvailability/bigVM/PAYGOverview";
 import RenewalManager from "../commitmentRenewal/RenewalManager";
 import { Tabs, Tab, TabList, TabPanel, Container, Button, Box } from "@cloudoperators/juno-ui-components";
@@ -134,7 +134,7 @@ const Overview = (props) => {
     case CEREBROKEY:
       currentTab = renderPAYG();
       break;
-    case COMMITMENTRENWALKEY:
+    case COMMITMENTRENEWALKEY:
       currentTab = renderRenewal();
       break;
     default:
@@ -146,7 +146,7 @@ const Overview = (props) => {
       <Tabs selectedIndex={currentTabIdx} onSelect={() => {}}>
         <TabList>
           {allAreas.map((area) =>
-            !scope.isProject() && area === COMMITMENTRENWALKEY ? null : (
+            !scope.isProject() && area === COMMITMENTRENEWALKEY ? null : (
               <Tab disabled={isEditing} onClick={() => onTabChange(area)} key={area}>
                 {t(area)}
               </Tab>
@@ -168,7 +168,7 @@ const Overview = (props) => {
         </TabList>
 
         {allAreas.map((area) =>
-          !scope.isProject() && area === COMMITMENTRENWALKEY ? null : <TabPanel key={area} className={"m-4"}></TabPanel>
+          !scope.isProject() && area === COMMITMENTRENEWALKEY ? null : <TabPanel key={area} className={"m-4"}></TabPanel>
         )}
       </Tabs>
       {currentTab}

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -16,12 +16,13 @@
 
 import React from "react";
 import Category from "./Category";
-import { createCommitmentStore } from "../StoreProvider";
+import { globalStore, createCommitmentStore } from "../StoreProvider";
 import useResetCommitment from "../../hooks/useResetCommitment";
 import { useParams, useNavigate, useLocation, Outlet } from "react-router";
 import { t, byUIString } from "../../lib/utils";
-import { ADVANCEDVIEW, CEREBROKEY } from "../../lib/constants";
+import { ADVANCEDVIEW, CEREBROKEY, COMMITMENTRENWALKEY } from "../../lib/constants";
 import PAYGOverview from "../paygAvailability/bigVM/PAYGOverview";
+import CommitmentRenewal from "../commitmentRenewal/Overview";
 import { Tabs, Tab, TabList, TabPanel, Container, Button, Box } from "@cloudoperators/juno-ui-components";
 import { getScrapeTime } from "../../lib/getScrapeTime";
 
@@ -29,8 +30,9 @@ const Overview = (props) => {
   const { canEdit } = props;
   const navigate = useNavigate();
   const location = useLocation();
-  const editableAreas = props.overview.editableAreas;
   const { isEditing } = createCommitmentStore();
+  const { scope } = globalStore();
+  const editableAreas = props.overview.editableAreas;
   const [advancedView, setAdvancedView] = React.useState(JSON.parse(localStorage.getItem(ADVANCEDVIEW)) || false);
   const allAreas = advancedView ? Object.keys(props.overview.areas) : editableAreas;
   const { currentArea = allAreas[0] } = useParams();
@@ -54,8 +56,9 @@ const Overview = (props) => {
   }, [currentArea]);
 
   // Hide tabs that should not be displayed in reduced resource view.
-  function onTabChange(currentArea) {
-    const areaIdx = allAreas.findIndex((area) => area === currentArea);
+  // A previous selected tab will route to the first displayed area.
+  function onTabChange(selectedArea) {
+    const areaIdx = allAreas.findIndex((area) => area === selectedArea);
     if (areaIdx < 0) {
       setCurrentTabIdx(0);
       navigate(`/${allAreas[0]}`);
@@ -65,21 +68,13 @@ const Overview = (props) => {
     navigate(`/${allAreas[areaIdx]}`);
   }
 
-  // On custom tab, directly route to it.
-  React.useEffect(() => {
-    if (currentArea == CEREBROKEY) {
-      const tabIdx = allAreas.length - 1;
-      setCurrentTabIdx(tabIdx);
-      navigate(`/${allAreas[tabIdx]}`);
-      return;
-    }
-  }, [advancedView]);
-
-  // Consider advanced view button click
+  // Consider advanced view button click.
+  // Set selected tab to the corresponding view (reduced | advanced)
   React.useEffect(() => {
     // Do not reroute on any other subroute. Matches: ("/", "/route", "/route/")
     // This would cause the refresh of the EditPanel to be rerouted to the main route.
-    const exp = new RegExp("^/[a-zA-Z0-9]*/?$").exec(location.pathname);
+    // '%' will be checked to capture special characters. F.e. URL encoding empty space = %20
+    const exp = new RegExp("^/[a-zA-Z0-9%]*/?$").exec(location.pathname);
     if (!exp) return;
     onTabChange(currentArea);
   }, [advancedView]);
@@ -130,10 +125,17 @@ const Overview = (props) => {
     );
   }
 
+  function renderRenewal() {
+    return <CommitmentRenewal />;
+  }
+
   let currentTab;
   switch (currentArea) {
     case CEREBROKEY:
       currentTab = renderPAYG();
+      break;
+    case COMMITMENTRENWALKEY:
+      currentTab = renderRenewal();
       break;
     default:
       currentTab = renderArea();
@@ -143,11 +145,13 @@ const Overview = (props) => {
     <Container px={false} className="mb-11">
       <Tabs selectedIndex={currentTabIdx} onSelect={() => {}}>
         <TabList>
-          {allAreas.map((area) => (
-            <Tab disabled={isEditing} onClick={() => onTabChange(area)} key={area}>
-              {t(area)}
-            </Tab>
-          ))}
+          {allAreas.map((area) =>
+            !scope.isProject() && area === COMMITMENTRENWALKEY ? null : (
+              <Tab disabled={isEditing} onClick={() => onTabChange(area)} key={area}>
+                {t(area)}
+              </Tab>
+            )
+          )}
           <div className="m-auto mr-0">
             <Button
               size="small"
@@ -163,9 +167,9 @@ const Overview = (props) => {
           </div>
         </TabList>
 
-        {allAreas.map((area) => (
-          <TabPanel key={area} className={"m-4"}></TabPanel>
-        ))}
+        {allAreas.map((area) =>
+          !scope.isProject() && area === COMMITMENTRENWALKEY ? null : <TabPanel key={area} className={"m-4"}></TabPanel>
+        )}
       </Tabs>
       {currentTab}
       {canEdit && <Outlet />}

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -168,7 +168,9 @@ const Overview = (props) => {
         </TabList>
 
         {allAreas.map((area) =>
-          !scope.isProject() && area === COMMITMENTRENEWALKEY ? null : <TabPanel key={area} className={"m-4"}></TabPanel>
+          !scope.isProject() && area === COMMITMENTRENEWALKEY ? null : (
+            <TabPanel key={area} className={"m-4"}></TabPanel>
+          )
         )}
       </Tabs>
       {currentTab}

--- a/src/hooks/useCommitmentFilter.js
+++ b/src/hooks/useCommitmentFilter.js
@@ -25,12 +25,16 @@ const useCommitmentFilter = () => {
     });
   }
 
-  function isPlanned(commitment) {
-    let planned = false;
-    if (commitment.confirm_by > Math.floor(Date.now() / 1000)) {
-      planned = true;
-    }
-    return planned;
+  function getCommitmentLabel(commitment) {
+    let label;
+    isActive(commitment)
+      ? (label = "Committed")
+      : isPending(commitment)
+        ? (label = "Pending")
+        : isPlanned(commitment)
+          ? (label = "Planned")
+          : (label = "");
+    return label;
   }
 
   function isPending(commitment) {
@@ -41,10 +45,25 @@ const useCommitmentFilter = () => {
     return pending;
   }
 
+  function isPlanned(commitment) {
+    let planned = false;
+    if (commitment.confirm_by > Math.floor(Date.now() / 1000)) {
+      planned = true;
+    }
+    return planned;
+  }
+
+  function isActive(commitment) {
+    const { confirmed_at: isConfirmed = false } = commitment;
+    return isConfirmed;
+  }
+
   return {
+    getCommitmentLabel,
     filterCommitments,
     isPending,
     isPlanned,
+    isActive,
   };
 };
 

--- a/src/hooks/useCommitmentFilter.js
+++ b/src/hooks/useCommitmentFilter.js
@@ -26,15 +26,10 @@ const useCommitmentFilter = () => {
   }
 
   function getCommitmentLabel(commitment) {
-    let label;
-    isActive(commitment)
-      ? (label = "Committed")
-      : isPending(commitment)
-        ? (label = "Pending")
-        : isPlanned(commitment)
-          ? (label = "Planned")
-          : (label = "");
-    return label;
+    if (isActive(commitment)) { return "Committed"; }
+    if (isPending(commitment)) { return "Pending"; }
+    if (isPlanned(commitment)) { return "Planned"; }
+    return "";
   }
 
   function isPending(commitment) {

--- a/src/hooks/useCommitmentFilter.js
+++ b/src/hooks/useCommitmentFilter.js
@@ -46,7 +46,7 @@ const useCommitmentFilter = () => {
   }
 
   function isPlanned(commitment) {
-    return commitment.confirm_by > Math.floor(Date.now() / 1000));
+    return commitment.confirm_by > Math.floor(Date.now() / 1000);
   }
 
   function isActive(commitment) {

--- a/src/hooks/useCommitmentFilter.js
+++ b/src/hooks/useCommitmentFilter.js
@@ -46,11 +46,7 @@ const useCommitmentFilter = () => {
   }
 
   function isPlanned(commitment) {
-    let planned = false;
-    if (commitment.confirm_by > Math.floor(Date.now() / 1000)) {
-      planned = true;
-    }
-    return planned;
+    return commitment.confirm_by > Math.floor(Date.now() / 1000));
   }
 
   function isActive(commitment) {

--- a/src/hooks/useCommitmentFilter.js
+++ b/src/hooks/useCommitmentFilter.js
@@ -26,18 +26,20 @@ const useCommitmentFilter = () => {
   }
 
   function getCommitmentLabel(commitment) {
-    if (isActive(commitment)) { return "Committed"; }
-    if (isPending(commitment)) { return "Pending"; }
-    if (isPlanned(commitment)) { return "Planned"; }
+    if (isActive(commitment)) {
+      return "Committed";
+    }
+    if (isPending(commitment)) {
+      return "Pending";
+    }
+    if (isPlanned(commitment)) {
+      return "Planned";
+    }
     return "";
   }
 
   function isPending(commitment) {
-    let pending = false;
-    if (commitment.confirm_by < Math.floor(Date.now() / 1000) && !("confirmed_at" in commitment)) {
-      pending = true;
-    }
-    return pending;
+    return commitment.confirm_by < Math.floor(Date.now() / 1000) && !("confirmed_at" in commitment);
   }
 
   function isPlanned(commitment) {
@@ -49,13 +51,7 @@ const useCommitmentFilter = () => {
     return isConfirmed;
   }
 
-  return {
-    getCommitmentLabel,
-    filterCommitments,
-    isPending,
-    isPlanned,
-    isActive,
-  };
+  return { getCommitmentLabel, filterCommitments, isPending, isPlanned, isActive };
 };
 
 export default useCommitmentFilter;

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -49,11 +49,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${domainID}/projects/${pid}`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            Accept: "application/json",
-            "X-Limes-V2-API-Preview": "per-az",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Limes-V2-API-Preview": "per-az", "X-Auth-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response);
@@ -67,11 +63,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${did}/projects/${pid}/commitments`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            Accept: "application/json",
-            "X-Limes-V2-API-Preview": "per-az",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Limes-V2-API-Preview": "per-az", "X-Auth-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response);
@@ -85,10 +77,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${did}/projects/${pid}/commitments/new`;
         const response = await fetch(url, {
           method: "POST",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token },
           body: JSON.stringify(payload),
         });
         return responseHandler(response);
@@ -102,10 +91,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${did}/projects/${pid}/commitments/${commitmentID}`;
         const response = await fetch(url, {
           method: "DELETE",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token },
         });
         if (!response.ok) {
           const text = await response.text();
@@ -116,15 +102,11 @@ const useQueryClientFn = (isMockApi) => {
     });
 
     queryClient.setMutationDefaults(["renewCommitment"], {
-      mutationFn: async ({ payload }) => {
-        const url = `${endpoint}/v1/domains/${projectID}/projects/${domainID}/commitments/renew`;
+      mutationFn: async ({ commitmentID }) => {
+        const url = `${endpoint}/v1/domains/${domainID}/projects/${projectID}/commitments/${commitmentID}/renew`;
         const response = await fetch(url, {
           method: "POST",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
-          body: JSON.stringify(payload),
+          headers: { Accept: "application/json", "X-Auth-Token": token },
         });
         if (!response.ok) {
           const text = await response.text();
@@ -141,10 +123,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${did}/projects/${pid}/commitments/can-confirm`;
         const response = await fetch(url, {
           method: "POST",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token },
           body: JSON.stringify(payload),
         });
         return responseHandler(response);
@@ -157,10 +136,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${did}/projects/${targetProject}/max-quota`;
         const response = await fetch(url, {
           method: "PUT",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token },
           body: JSON.stringify(payload),
         });
         if (!response.ok) {
@@ -178,10 +154,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/commitment-conversion/${serviceType}/${resourceName}`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response);
@@ -195,10 +168,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${did}/projects/${pid}/commitments/${commitmentID}/convert`;
         const response = await fetchProxy(url, {
           method: "POST",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token },
           body: JSON.stringify(payload),
         });
         return responseHandler(response);
@@ -212,10 +182,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${did}/projects/${pid}/commitments/${commitmentID}/update-duration`;
         const response = await fetchProxy(url, {
           method: "POST",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token },
           body: JSON.stringify(payload),
         });
         return responseHandler(response);
@@ -235,11 +202,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${dID}`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            Accept: "application/json",
-            "X-Limes-V2-API-Preview": "per-az",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Limes-V2-API-Preview": "per-az", "X-Auth-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response);
@@ -253,11 +216,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${dID}/projects?service=${service}&resource=${resource}`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            Accept: "application/json",
-            "X-Limes-V2-API-Preview": "per-az",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Limes-V2-API-Preview": "per-az", "X-Auth-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response);
@@ -270,10 +229,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${dID}/projects/${projectID}/commitments/${commitmentID}/start-transfer`;
         const response = await fetchProxy(url, {
           method: "POST",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token },
           body: JSON.stringify(payload),
         });
         return responseHandler(response);
@@ -286,11 +242,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains/${dID}/projects/${projectID}/transfer-commitment/${commitmentID}`;
         const response = await fetchProxy(url, {
           method: "POST",
-          headers: {
-            Accept: "application/json",
-            "X-Auth-Token": token,
-            "Transfer-Token": transferToken,
-          },
+          headers: { Accept: "application/json", "X-Auth-Token": token, "Transfer-Token": transferToken },
         });
         return responseHandler(response);
       },
@@ -307,11 +259,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = isDetail ? `${endpoint}/v1/clusters/current?detail` : `${endpoint}/v1/clusters/current`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            Accept: "application/json",
-            "X-Limes-V2-API-Preview": "per-az",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Limes-V2-API-Preview": "per-az", "X-Auth-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response);
@@ -325,11 +273,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/domains?service=${service}&resource=${resource}`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            Accept: "application/json",
-            "X-Limes-V2-API-Preview": "per-az",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Limes-V2-API-Preview": "per-az", "X-Auth-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response);
@@ -351,10 +295,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `https://${host}${path}/bigvm_resources`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            "X-Requested-With": "XMLHttpRequest",
-            "X-CSRF-Token": token,
-          },
+          headers: { "X-Requested-With": "XMLHttpRequest", "X-CSRF-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response, false);
@@ -370,11 +311,7 @@ const useQueryClientFn = (isMockApi) => {
         const url = `${endpoint}/v1/commitments/${transferToken}`;
         const response = await fetchProxy(url, {
           method: "GET",
-          headers: {
-            Accept: "application/json",
-            "X-Limes-V2-API-Preview": "per-az",
-            "X-Auth-Token": token,
-          },
+          headers: { Accept: "application/json", "X-Limes-V2-API-Preview": "per-az", "X-Auth-Token": token },
           ...{ mock: isMockApi },
         });
         return responseHandler(response);

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -115,6 +115,25 @@ const useQueryClientFn = (isMockApi) => {
       },
     });
 
+    queryClient.setMutationDefaults(["renewCommitment"], {
+      mutationFn: async ({ payload }) => {
+        const url = `${endpoint}/v1/domains/${projectID}/projects/${domainID}/commitments/renew`;
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            Accept: "application/json",
+            "X-Auth-Token": token,
+          },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          const text = await response.text();
+          throw new Error(`Network error: ${text} (Code: ${response.status})`);
+        }
+        return response;
+      },
+    });
+
     queryClient.setMutationDefaults(["canConfirm"], {
       mutationFn: async ({ payload, queryKey }) => {
         queryKey[0] ? (pid = queryKey[0]) : (pid = projectID);

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -17,7 +17,7 @@
 export const COMMITMENTID = "AddCommitment";
 export const ADVANCEDVIEW = "advancedView";
 export const CEREBROKEY = "PAYG Availability";
-export const COMMITMENTRENWALKEY = "Renewal";
+export const COMMITMENTRENEWALKEY = "Renewal";
 export const PAYG_AZUNAWARE_KEY = "Whole Region";
 
 //used to reset the last commitment to default values.

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -17,6 +17,7 @@
 export const COMMITMENTID = "AddCommitment";
 export const ADVANCEDVIEW = "advancedView";
 export const CEREBROKEY = "PAYG Availability";
+export const COMMITMENTRENWALKEY = "Renewal";
 export const PAYG_AZUNAWARE_KEY = "Whole Region";
 
 //used to reset the last commitment to default values.

--- a/src/lib/fixtures/limes_commitment_api.json
+++ b/src/lib/fixtures/limes_commitment_api.json
@@ -80,7 +80,7 @@
           "duration": "1 year",
           "requested_at": 1699956655,
           "confirmed_at": 1699957274,
-          "expires_at": 1731579674
+          "expires_at": 1743458400
         },
         {
           "id": 122,
@@ -92,7 +92,7 @@
           "duration": "1 year",
           "requested_at": 1699956655,
           "confirmed_at": 1699957274,
-          "expires_at": 1731579674
+          "expires_at": 1743458400
         },
         {
           "id": 123,
@@ -115,6 +115,57 @@
           "duration": "3 years",
           "confirmed_at": 1699957274,
           "requested_at": 1699979577
+        },
+        {
+          "id": 125,
+          "service_type": "compute",
+          "resource_name": "instances",
+          "availability_zone": "qa-de-1a",
+          "amount": 59,
+          "unit": "",
+          "duration": "1 year",
+          "requested_at": 1699956655,
+          "confirmed_at": 1699957274,
+          "can_be_deleted": true,
+          "expires_at": 1743458400
+        },
+        {
+          "id": 126,
+          "service_type": "compute",
+          "resource_name": "instances_hana_c120_m960",
+          "availability_zone": "qa-de-1a",
+          "amount": 1,
+          "unit": "",
+          "transfer_status": "unlisted",
+          "duration": "3 years",
+          "confirmed_at": 1699957274,
+          "requested_at": 1699979577,
+          "expires_at": 1743458400
+        },
+        {
+          "id": 127,
+          "service_type": "compute",
+          "resource_name": "instances_hana_c120_m960",
+          "availability_zone": "qa-de-1a",
+          "amount": 1,
+          "unit": "",
+          "transfer_status": "unlisted",
+          "duration": "3 years",
+          "confirmed_at": 1699957274,
+          "requested_at": 1699979577,
+          "expires_at": 1743458400
+        },
+        {
+          "id": 128,
+          "service_type": "compute",
+          "resource_name": "instances_hana_c120_m960",
+          "availability_zone": "qa-de-1a",
+          "amount": 1,
+          "unit": "",
+          "duration": "3 years",
+          "confirm_by": 1699957274,
+          "requested_at": 1699979577,
+          "expires_at": 1743458400
         }
       ]
     }

--- a/src/lib/fixtures/limes_commitment_api.json
+++ b/src/lib/fixtures/limes_commitment_api.json
@@ -80,7 +80,7 @@
           "duration": "1 year",
           "requested_at": 1699956655,
           "confirmed_at": 1699957274,
-          "expires_at": 1743458400
+          "expires_at": 1731579674
         },
         {
           "id": 122,
@@ -92,7 +92,7 @@
           "duration": "1 year",
           "requested_at": 1699956655,
           "confirmed_at": 1699957274,
-          "expires_at": 1743458400
+          "expires_at": 1731579674
         },
         {
           "id": 123,
@@ -115,57 +115,6 @@
           "duration": "3 years",
           "confirmed_at": 1699957274,
           "requested_at": 1699979577
-        },
-        {
-          "id": 125,
-          "service_type": "compute",
-          "resource_name": "instances",
-          "availability_zone": "qa-de-1a",
-          "amount": 59,
-          "unit": "",
-          "duration": "1 year",
-          "requested_at": 1699956655,
-          "confirmed_at": 1699957274,
-          "can_be_deleted": true,
-          "expires_at": 1743458400
-        },
-        {
-          "id": 126,
-          "service_type": "compute",
-          "resource_name": "instances_hana_c120_m960",
-          "availability_zone": "qa-de-1a",
-          "amount": 1,
-          "unit": "",
-          "transfer_status": "unlisted",
-          "duration": "3 years",
-          "confirmed_at": 1699957274,
-          "requested_at": 1699979577,
-          "expires_at": 1743458400
-        },
-        {
-          "id": 127,
-          "service_type": "compute",
-          "resource_name": "instances_hana_c120_m960",
-          "availability_zone": "qa-de-1a",
-          "amount": 1,
-          "unit": "",
-          "transfer_status": "unlisted",
-          "duration": "3 years",
-          "confirmed_at": 1699957274,
-          "requested_at": 1699979577,
-          "expires_at": 1743458400
-        },
-        {
-          "id": 128,
-          "service_type": "compute",
-          "resource_name": "instances_hana_c120_m960",
-          "availability_zone": "qa-de-1a",
-          "amount": 1,
-          "unit": "",
-          "duration": "3 years",
-          "confirm_by": 1699957274,
-          "requested_at": 1699979577,
-          "expires_at": 1743458400
         }
       ]
     }

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CEREBROKEY, COMMITMENTRENWALKEY } from "../constants";
+import { CEREBROKEY, COMMITMENTRENEWALKEY } from "../constants";
 import { unusedCommitments, uncommittedUsage } from "../../lib/utils";
 import { Scope } from "../scope";
 
@@ -289,7 +289,7 @@ const limesStore = (set, get) => ({
         // HANA BigVMResource needs to be added manually to the areas with the coressponding CEREBRO key.
         areas.set(CEREBROKEY, true);
         // Renewal is a custom area that allows to renew expiring commitments.
-        areas.set(COMMITMENTRENWALKEY, true);
+        areas.set(COMMITMENTRENEWALKEY, true);
         const editableAreas = Array.from(areas.keys());
 
         // `overview` is what the Overview component needs.
@@ -304,7 +304,7 @@ const limesStore = (set, get) => ({
           categories: groupKeys(Object.entries(categories).map(([catName, cat]) => [cat.serviceType, catName])),
         };
         overview.areas[CEREBROKEY] = ["cerebro"];
-        overview.areas[COMMITMENTRENWALKEY] = ["renewal"];
+        overview.areas[COMMITMENTRENEWALKEY] = ["renewal"];
 
         return { metadata, categories, overview };
       },

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CEREBROKEY } from "../constants";
+import { CEREBROKEY, COMMITMENTRENWALKEY } from "../constants";
 import { unusedCommitments, uncommittedUsage } from "../../lib/utils";
 import { Scope } from "../scope";
 
@@ -288,6 +288,8 @@ const limesStore = (set, get) => ({
         });
         // HANA BigVMResource needs to be added manually to the areas with the coressponding CEREBRO key.
         areas.set(CEREBROKEY, true);
+        // Renewal is a custom area that allows to renew expiring commitments.
+        areas.set(COMMITMENTRENWALKEY, true)
         const editableAreas = Array.from(areas.keys());
 
         // `overview` is what the Overview component needs.
@@ -302,6 +304,7 @@ const limesStore = (set, get) => ({
           categories: groupKeys(Object.entries(categories).map(([catName, cat]) => [cat.serviceType, catName])),
         };
         overview.areas[CEREBROKEY] = ["cerebro"];
+        overview.areas[COMMITMENTRENWALKEY] = ["renewal"]
 
         return { metadata, categories, overview };
       },

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -289,7 +289,7 @@ const limesStore = (set, get) => ({
         // HANA BigVMResource needs to be added manually to the areas with the coressponding CEREBRO key.
         areas.set(CEREBROKEY, true);
         // Renewal is a custom area that allows to renew expiring commitments.
-        areas.set(COMMITMENTRENWALKEY, true)
+        areas.set(COMMITMENTRENWALKEY, true);
         const editableAreas = Array.from(areas.keys());
 
         // `overview` is what the Overview component needs.
@@ -304,7 +304,7 @@ const limesStore = (set, get) => ({
           categories: groupKeys(Object.entries(categories).map(([catName, cat]) => [cat.serviceType, catName])),
         };
         overview.areas[CEREBROKEY] = ["cerebro"];
-        overview.areas[COMMITMENTRENWALKEY] = ["renewal"]
+        overview.areas[COMMITMENTRENWALKEY] = ["renewal"];
 
         return { metadata, categories, overview };
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -11,7 +11,7 @@ function withOpacity(variableName) {
   };
 }
 
-module.exports = {
+export default {
   presets: [
     require("@cloudoperators/juno-ui-components/build/lib/tailwind.config"), // important, do not change
   ],


### PR DESCRIPTION
This a PR to add the commitment renewal functionality.
Limes Ref: https://github.com/sapcc/limes/pull/674

Goal is to display commitments that are about to expire. The user has the option to:
* Renew all commitments
* Renew commitments from a specific category
* Renew singular commitments

Below the Renewal table, a inconistency table will be displayed. It shows commitments in trasfer, pending commitmetns or commitments with another state that should be fixed before they can be renewed.
I opt to have this view, because before a renewal takes place, a clean state should be a prerequisite.

Image:
![image](https://github.com/user-attachments/assets/164e29b4-8017-409b-aff9-65941f7b744d)

(the commitments will now be sorted by their category name first...)
Todos:
- [x] React to a `was_extended` attribute from the API in order to not list the commitments despite them beeing renewed already.
- [x] Omit a table if no applicable commitments are found.
- [x] Add proper unit tests

During development I thought about how we get the renwable commitments. We can:
* Get the `commitments` API and filter them out at UI level (currently implemented)
* Implement a separate endpoint that only gets renwable commitments
* Add another attribute to the existing `commitments` endpoint.

A separate endpoint should probably be implemented. However, it should also include the `inconsistencies` and that part was implemeted by speculation. I would like to hear your opinion on them first (correctness etc.)
If they don't get implemented there (and are omitted instead), the UI still needs to filter them out from the existing `commitment` endpoint.

Adding another attribute to the existing `commitment` API bears the same problem above with the inconistencies. Then the attribute should support different states.