### PR TITLE
update juno-ui-components to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sapcc/limes-ui",
-  "version": "1.3.9",
+  "version": "1.3.10",
   "author": "VoigtS",
   "license": "MIT",
   "source": "src/index.js",
@@ -118,7 +118,7 @@
     }
   },
   "dependencies": {
-    "@cloudoperators/juno-ui-components": "2.38.0",
+    "@cloudoperators/juno-ui-components": "2.38.2",
     "@cloudoperators/juno-url-state-provider": "*",
     "@cloudoperators/juno-utils": "*",
     "cypress": "^14.0.0",


### PR DESCRIPTION
this is needed to get the latest juno-ui-components for upgrading elektra image to alpine 3.21 that have a newer node version