### PR TITLE
[feat] Add notification on commitment confirmation

### DIFF
--- a/.changeset/bitter-wasps-fry.md
+++ b/.changeset/bitter-wasps-fry.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+Add notification option for planned commitments

--- a/src/components/commitment/Modals/CommitmentModal.js
+++ b/src/components/commitment/Modals/CommitmentModal.js
@@ -34,13 +34,9 @@ import { formatTimeISO8160 } from "../../../lib/utils";
 const label = "font-semibold";
 
 const CommitmentModal = (props) => {
-  const { action, az, canConfirm, commitment, minConfirmDate, onModalClose, subText, title } = {
-    ...props,
-  };
+  const { action, az, canConfirm, commitment, minConfirmDate, onModalClose, subText, title } = { ...props };
   const unit = new Unit(commitment.unit);
-  const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
-    confirmationText: subText,
-  });
+  const { ConfirmInput, inputProps, checkInput } = useConfirmInput({ confirmationText: subText });
   const hasMinConfirmDate = minConfirmDate ? true : false;
   // Show Calendar if: 1.) min_confirm_by field is set 2.) Not enough capacity is available on limes.
   const [showCalendar, setShowCalendar] = React.useState(hasMinConfirmDate || !canConfirm);
@@ -50,6 +46,7 @@ const CommitmentModal = (props) => {
   const startDate = minConfirmDate ? moment.unix(minConfirmDate)._d : moment()._d;
   const [selectedDate, setSelectedDate] = React.useState(startDate);
   const formattedDate = formatTimeISO8160(moment(selectedDate).unix());
+  const notifyOnConfirm = React.useRef(false);
 
   function onConfirm() {
     if (!selectedDate) return;
@@ -70,7 +67,7 @@ const CommitmentModal = (props) => {
     // The API confirms commitments without confirm_by instantly.
     const sendConfirmBy = showCalendar;
     if (sendConfirmBy) {
-      action(confirm_by);
+      action(confirm_by, notifyOnConfirm.current);
     } else {
       action();
     }
@@ -114,6 +111,7 @@ const CommitmentModal = (props) => {
             {commitment.duration + (commitment?.durationLabel && " " + "(" + commitment.durationLabel + ")")}
           </DataGridCell>
         </DataGridRow>
+        <DataGridRow></DataGridRow>
         <DataGridRow>
           <DataGridCell className={label}>Activation</DataGridCell>
           <DataGridCell>
@@ -126,6 +124,19 @@ const CommitmentModal = (props) => {
               label="immediately"
             />
           </DataGridCell>
+          {showCalendar && (
+            <>
+              <DataGridCell className={label}>Notificaton</DataGridCell>
+              <DataGridCell>
+                <Checkbox
+                  label="send mail on confirm"
+                  onClick={() => {
+                    notifyOnConfirm.current = !notifyOnConfirm.current;
+                  }}
+                />
+              </DataGridCell>
+            </>
+          )}
         </DataGridRow>
         {showCalendar && (
           <DataGridRow>

--- a/src/components/commitment/Modals/CommitmentModal.js
+++ b/src/components/commitment/Modals/CommitmentModal.js
@@ -111,7 +111,6 @@ const CommitmentModal = (props) => {
             {commitment.duration + (commitment?.durationLabel && " " + "(" + commitment.durationLabel + ")")}
           </DataGridCell>
         </DataGridRow>
-        <DataGridRow></DataGridRow>
         <DataGridRow>
           <DataGridCell className={label}>Activation</DataGridCell>
           <DataGridCell>

--- a/src/components/commitment/Modals/CommitmentModal.test.js
+++ b/src/components/commitment/Modals/CommitmentModal.test.js
@@ -155,6 +155,7 @@ describe("test commitment creation modal", () => {
     act(() => {
       screen.getByRole("checkbox").click();
     });
+    expect(screen.getByText("Notificaton")).toBeInTheDocument();
     expect(screen.getByText(/January 2024/i)).toBeInTheDocument();
   });
 });

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -139,11 +139,13 @@ const EditPanel = (props) => {
     );
   }, [isSubmitting]);
 
-  function postCommitment(confirm_by = null) {
+  function postCommitment(confirm_by = null, notifyOnConfirm = false) {
     const currentProjectID = currentProject?.metadata?.id;
     const currentDomainID = scope.isCluster() ? currentProject.metadata.domainID : null;
     setCommitmentIsLoading(true);
-    const payload = confirm_by ? { ...newCommitment, id: "", confirm_by: confirm_by } : { ...newCommitment, id: "" };
+    const payload = confirm_by
+      ? { ...newCommitment, id: "", confirm_by: confirm_by, notify_on_confirm: notifyOnConfirm }
+      : { ...newCommitment, id: "" };
     commit.mutate(
       {
         payload: {


### PR DESCRIPTION
Allow the user to be notified if a planned commitment gets confirmed.
This option is only available for the creation of planned commitments in the UI.

<img width="481" alt="image" src="https://github.com/user-attachments/assets/9aebd3d0-978b-4073-87c4-1a8af94eabf4" />
