### PR TITLE
Renewal: Disable actions on missing edit role

### DIFF
--- a/.changeset/tall-poems-refuse.md
+++ b/.changeset/tall-poems-refuse.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+disable commitment renwal actions on missing permissions

--- a/.changeset/tall-poems-refuse.md
+++ b/.changeset/tall-poems-refuse.md
@@ -2,4 +2,4 @@
 "@sapcc/limes-ui": patch
 ---
 
-disable commitment renwal actions on missing permissions
+disable commitment renewal actions on missing permissions

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -39,9 +39,11 @@ export const renewableInfoHint = [
   "We will send mail notifications when active commitments are about to expire.",
 ];
 export const inconsistentInfoText = "Resolve the state of the listed commitments first.";
+export const missingRole =
+  "You are missing the permissions to edit this page. Please forward this page to a resource admin.";
 
 const CommitmentRenewal = (props) => {
-  const { renewable = [], inconsistent = [] } = props;
+  const { renewable = [], inconsistent = [], canEdit = false } = props;
   const hasRenewable = renewable.length > 0;
   const hasInconsistencies = inconsistent.length > 0;
   const [showModal, setShowModal] = React.useState(false);
@@ -97,6 +99,7 @@ const CommitmentRenewal = (props) => {
         {showRenewable && (
           <DataGridCell>
             <Button
+              disabled={!canEdit}
               data-testid={"renew" + c.id}
               title="Renew Commitment"
               className="w-10"
@@ -138,10 +141,11 @@ const CommitmentRenewal = (props) => {
           <span className="whitespace-pre-line">{toast}</span>
         </Message>
       )}
+      {!canEdit && <Message className={"mb-1"} variant="warning" text={missingRole} />}
       {hasRenewable ? (
         <div>
           {!hasInconsistencies && (
-            <Message data-testid="inconsistentInfoHint" className="mb-2" dismissible={true}>
+            <Message data-testid="infoHint" className="mb-2" dismissible={true}>
               {renewableInfoHint.map((hint, i) => (
                 <div key={i}>{hint}</div>
               ))}
@@ -162,6 +166,7 @@ const CommitmentRenewal = (props) => {
               ))}
             </Select>
             <Button
+              disabled={!canEdit}
               data-testid="renewMultiple"
               title="Renew all"
               className="w-10"

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -24,7 +24,8 @@ import useCommitmentFilter from "../../hooks/useCommitmentFilter";
 
 // RenewalManager fetches renwable commitments for the current scope.
 // Currently only available at project level.
-const RenewalManager = () => {
+const RenewalManager = (props) => {
+  const { canEdit = false } = props;
   const { commitments } = projectStore();
   const { isActive, getCommitmentLabel } = useCommitmentFilter();
   const now = moment().utc();
@@ -71,7 +72,9 @@ const RenewalManager = () => {
     return 0;
   }
 
-  return <CommitmentRenewal renewable={renewableCommitments} inconsistent={inconsistentCommitments} />;
+  return (
+    <CommitmentRenewal canEdit={canEdit} renewable={renewableCommitments} inconsistent={inconsistentCommitments} />
+  );
 };
 
 export default RenewalManager;

--- a/src/components/commitmentRenewal/renewal.test.js
+++ b/src/components/commitmentRenewal/renewal.test.js
@@ -102,7 +102,7 @@ describe("Commitment renewal tests", () => {
   test("Expect renewable and inconsistent commitments", async () => {
     const now = moment().utc();
     const expire = now.add(2, "months").unix();
-    const renewableCommitmnets = [
+    const renewableCommitments = [
       {
         id: 1,
         service_type: "service_1",
@@ -151,7 +151,7 @@ describe("Commitment renewal tests", () => {
       <PortalProvider>
         <StoreProvider>
           <QueryClientProvider client={queryClient}>
-            <CommitmentRenewal canEdit={true} renewable={renewableCommitmnets} inconsistent={inconsistentCommitments} />
+            <CommitmentRenewal canEdit={true} renewable={renewableCommitments} inconsistent={inconsistentCommitments} />
             {children}
           </QueryClientProvider>
         </StoreProvider>
@@ -254,7 +254,7 @@ describe("Commitment renewal tests", () => {
   test("Renewables but no inconistencies", async () => {
     const now = moment().utc();
     const expire = now.add(2, "months").unix();
-    const renewableCommitmnets = [
+    const renewableCommitments = [
       {
         id: 1,
         service_type: "service_1",
@@ -279,7 +279,7 @@ describe("Commitment renewal tests", () => {
       <PortalProvider>
         <StoreProvider>
           <QueryClientProvider client={queryClient}>
-            <CommitmentRenewal canEdit={true} renewable={renewableCommitmnets} />
+            <CommitmentRenewal canEdit={true} renewable={renewableCommitments} />
             {children}
           </QueryClientProvider>
         </StoreProvider>
@@ -294,7 +294,7 @@ describe("Commitment renewal tests", () => {
   test("Missing access role", async () => {
     const now = moment().utc();
     const expire = now.add(2, "months").unix();
-    const renewableCommitmnets = [
+    const renewableCommitments = [
       {
         id: 1,
         service_type: "service_1",
@@ -319,7 +319,7 @@ describe("Commitment renewal tests", () => {
       <PortalProvider>
         <StoreProvider>
           <QueryClientProvider client={queryClient}>
-            <CommitmentRenewal canEdit={false} renewable={renewableCommitmnets} />
+            <CommitmentRenewal canEdit={false} renewable={renewableCommitments} />
             {children}
           </QueryClientProvider>
         </StoreProvider>

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -125,8 +125,8 @@ const Overview = (props) => {
     );
   }
 
-  function renderRenewal() {
-    return <RenewalManager />;
+  function renderRenewal(canEdit) {
+    return <RenewalManager canEdit={canEdit} />;
   }
 
   let currentTab;
@@ -135,7 +135,7 @@ const Overview = (props) => {
       currentTab = renderPAYG();
       break;
     case COMMITMENTRENEWALKEY:
-      currentTab = renderRenewal();
+      currentTab = renderRenewal(canEdit);
       break;
     default:
       currentTab = renderArea();


### PR DESCRIPTION
The previous implementation did not react properly to users which have no edit permissions for the project.
This PR disables the renewal buttons and displays a warning about how to act in this situation if thats the case.