### PR TITLE
fix resource bar quota display

### DIFF
--- a/.changeset/shiny-dancers-swim.md
+++ b/.changeset/shiny-dancers-swim.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+Fix: add missing tracksQuota property to the Panel component. Fix wrongly displayed quota bar values on usage only resources"

--- a/src/components/mainView/Category.js
+++ b/src/components/mainView/Category.js
@@ -18,6 +18,7 @@ import React from "react";
 import { t, sortByLogicalOrderAndName, tracksQuota } from "../../lib/utils";
 import Resource from "./Resource";
 import { createCommitmentStore } from "../StoreProvider";
+import { ErrorBoundary } from "../../lib/ErrorBoundary";
 
 const categoryTitle = `
     text-lg 
@@ -54,7 +55,11 @@ const Category = (props) => {
         <h1 className={`category-title ${categoryTitle}`}>{t(props.categoryName)}</h1>
         <div className={`category-content ${categoryContent}`}>
           {sortByLogicalOrderAndName(advancedView ? resources : editableResources).map((res) => {
-            return <Resource key={res.name} resource={res} {...forwardProps} tracksQuota={tracksQuota(res)} />;
+            return (
+              <ErrorBoundary key={res.name}>
+                <Resource resource={res} {...forwardProps} tracksQuota={tracksQuota(res)} />
+              </ErrorBoundary>
+            );
           })}
         </div>
       </div>

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -119,6 +119,10 @@ const Resource = (props) => {
     serviceType: serviceType,
   };
 
+  if (tracksQuota === undefined) {
+    throw new Error("Missing property: tracksQuota");
+  }
+
   return (
     <div className={!props.isPanelView ? `bar-card ${barGroupContainer}` : `bar-card-panel`}>
       <div

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -103,7 +103,7 @@ const Resource = (props) => {
   const { scope } = globalStore();
   const displayName = t(props.resource.name);
   // displayedUsage ensures that resources without commitments get the project usage displayed.
-  const displayedUsage = usagePerCommitted > 0 ? usagePerCommitted : usagePerQuota;
+  const displayedUsage = usagePerCommitted > 0 ? (tracksQuota ? usagePerCommitted : resource.usage) : usagePerQuota;
   const { resetCommitment } = useResetCommitment();
   // Bar length on project/domain level is Quota. On Cluster level it is capacity.
   const capacityOrQuota = scope.isCluster() ? capacity || 0 : originalQuota;

--- a/src/components/mainView/Resource.test.js
+++ b/src/components/mainView/Resource.test.js
@@ -19,7 +19,7 @@ import Resource from "./Resource";
 import { Scope } from "../../lib/scope";
 import { MemoryRouter } from "react-router";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
-import { act, renderHook, screen, waitFor } from "@testing-library/react";
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
 import StoreProvider, { globalStore, globalStoreActions } from "../StoreProvider";
 
@@ -102,5 +102,119 @@ describe("Resource tests", () => {
       result.current.globalStoreActions.setScope(scope);
     });
     expect(screen.getByTestId("setMaxQuotaPanel")).toBeInTheDocument();
+  });
+});
+
+describe("Resource bar test", () => {
+  let actions;
+  beforeEach(() => {
+    const wrapper = ({ children }) => <StoreProvider>{children}</StoreProvider>;
+    const store = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+    actions = store.result.current.globalStoreActions;
+  });
+  test("resources with quota tracking", async () => {
+    let scope = new Scope({ projectID: "123", domainID: "456" });
+    function getProjectData(committed = null) {
+      return {
+        project: {
+          id: "123",
+          services: [
+            {
+              type: "testType",
+              resources: [
+                {
+                  name: "testResource",
+                  area: "testArea",
+                  commitment_config: {
+                    durations: ["1 year", "2 years", "3 years"],
+                  },
+                  per_az: {
+                    "zone-a": {
+                      usage: 25,
+                      quota: 50,
+                      committed,
+                    },
+                    "zone-b": {
+                      usage: 25,
+                      quota: 50,
+                      committed,
+                    },
+                    "zone-c": {
+                      usage: 0,
+                      quota: 50,
+                    },
+                  },
+                  quota: 150,
+                  usage: 50,
+                },
+              ],
+            },
+          ],
+        },
+      };
+    }
+    const committed = {
+      "1 year": 10,
+    };
+
+    const forwardProps = {
+      area: "testArea",
+      canEdit: true,
+      categoryName: "testCategory",
+      serviceType: "testService",
+    };
+
+    let res = actions.restructureReport(getProjectData().project).categories.testType.resources[0];
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <Resource key={res.name} resource={res} {...forwardProps} tracksQuota={true} />
+              {children}
+            </MemoryRouter>
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+    const { result, rerender } = await waitFor(() => {
+      return renderHook(
+        () => ({
+          globalStore: globalStore(),
+          globalStoreActions: globalStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+
+    // Resourcebar values without commitments
+    expect(screen.getByText("50/150")).toBeInTheDocument();
+    expect(screen.queryAllByText("25/50").length).toEqual(2);
+    expect(screen.getByText("0/50")).toBeInTheDocument();
+
+    // Resourebar values with commitments
+    res = actions.restructureReport(getProjectData(committed).project).categories.testType.resources[0];
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+    // sumbar values (left and right)
+    expect(screen.getByText("20/20")).toBeInTheDocument();
+    expect(screen.getByText("30/130")).toBeInTheDocument();
+    // zone-a and zone-b (left and right)
+    expect(screen.queryAllByText("10/10").length).toEqual(2);
+    expect(screen.queryAllByText("15/40").length).toEqual(2);
+    // zone-c does not contain commitments and displays the basic bar layout.
+    expect(screen.getByText("0/50")).toBeInTheDocument();
   });
 });

--- a/src/components/mainView/Resource.test.js
+++ b/src/components/mainView/Resource.test.js
@@ -19,7 +19,7 @@ import Resource from "./Resource";
 import { Scope } from "../../lib/scope";
 import { MemoryRouter } from "react-router";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
-import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { act, renderHook, screen, waitFor } from "@testing-library/react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
 import StoreProvider, { globalStore, globalStoreActions } from "../StoreProvider";
 

--- a/src/components/mainView/Resource.test.js
+++ b/src/components/mainView/Resource.test.js
@@ -120,7 +120,7 @@ describe("Resource bar test", () => {
   });
   test("resources with quota tracking", async () => {
     let scope = new Scope({ projectID: "123", domainID: "456" });
-    function getProjectData(committed = null) {
+    function getProjectData(committed = null, usage = 50) {
       return {
         project: {
           id: "123",
@@ -136,12 +136,12 @@ describe("Resource bar test", () => {
                   },
                   per_az: {
                     "zone-a": {
-                      usage: 25,
+                      usage: usage / 2,
                       quota: 50,
                       committed,
                     },
                     "zone-b": {
-                      usage: 25,
+                      usage: usage / 2,
                       quota: 50,
                       committed,
                     },
@@ -151,7 +151,7 @@ describe("Resource bar test", () => {
                     },
                   },
                   quota: 150,
-                  usage: 50,
+                  usage: usage,
                 },
               ],
             },
@@ -216,6 +216,21 @@ describe("Resource bar test", () => {
     expect(screen.queryAllByText("10/10").length).toEqual(2);
     expect(screen.queryAllByText("15/40").length).toEqual(2);
     // zone-c does not contain commitments and displays the basic bar layout.
+    expect(screen.getByText("0/50")).toBeInTheDocument();
+
+    // Sumbar (left) is not filled completely (usage < commitments)
+    res = actions.restructureReport(getProjectData(committed, 10).project).categories.testType.resources[0];
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+    // sumbar values (left and right)
+    expect(screen.getByText("10/20")).toBeInTheDocument();
+    expect(screen.getByText("0/130")).toBeInTheDocument();
+    // zone-a and zone-b (left and right)
+    expect(screen.queryAllByText("5/10").length).toEqual(2);
+    expect(screen.queryAllByText("0/40").length).toEqual(2);
+    // zone-c
     expect(screen.getByText("0/50")).toBeInTheDocument();
   });
 

--- a/src/components/mainView/Resource.test.js
+++ b/src/components/mainView/Resource.test.js
@@ -22,6 +22,7 @@ import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import { act, renderHook, screen, waitFor } from "@testing-library/react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
 import StoreProvider, { globalStore, globalStoreActions } from "../StoreProvider";
+import { tracksQuota } from "../../lib/utils";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -176,7 +177,7 @@ describe("Resource bar test", () => {
         <StoreProvider>
           <QueryClientProvider client={queryClient}>
             <MemoryRouter>
-              <Resource key={res.name} resource={res} {...forwardProps} tracksQuota={true} />
+              <Resource key={res.name} resource={res} {...forwardProps} tracksQuota={tracksQuota(res)} />
               {children}
             </MemoryRouter>
           </QueryClientProvider>
@@ -216,5 +217,103 @@ describe("Resource bar test", () => {
     expect(screen.queryAllByText("15/40").length).toEqual(2);
     // zone-c does not contain commitments and displays the basic bar layout.
     expect(screen.getByText("0/50")).toBeInTheDocument();
+  });
+
+  test("usage only resources", async () => {
+    let scope = new Scope({ projectID: "123", domainID: "456" });
+    function getProjectData(committed = null) {
+      return {
+        project: {
+          id: "123",
+          services: [
+            {
+              type: "testType",
+              resources: [
+                {
+                  name: "testResource",
+                  area: "testArea",
+                  commitment_config: {
+                    durations: ["1 year", "2 years", "3 years"],
+                  },
+                  per_az: {
+                    "zone-a": {
+                      usage: 50,
+                      committed,
+                    },
+                    "zone-b": {
+                      usage: 50,
+                      committed,
+                    },
+                    "zone-c": {
+                      usage: 0,
+                    },
+                  },
+                  usage: 100,
+                },
+              ],
+            },
+          ],
+        },
+      };
+    }
+    const committed = {
+      "1 year": 5,
+    };
+
+    const forwardProps = {
+      area: "testArea",
+      canEdit: true,
+      categoryName: "testCategory",
+      serviceType: "testService",
+    };
+
+    let res = actions.restructureReport(getProjectData().project).categories.testType.resources[0];
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <Resource key={res.name} resource={res} {...forwardProps} tracksQuota={tracksQuota(res)} />
+              {children}
+            </MemoryRouter>
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+    const { result, rerender } = await waitFor(() => {
+      return renderHook(
+        () => ({
+          globalStore: globalStore(),
+          globalStoreActions: globalStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+
+    // Resourcebar values without commitments
+    expect(screen.getByText("100/100")).toBeInTheDocument();
+    expect(screen.queryAllByText("50/50").length).toEqual(2);
+    expect(screen.getByText(/no quota/i)).toBeInTheDocument();
+
+    // Resourebar values with commitments
+    res = actions.restructureReport(getProjectData(committed).project).categories.testType.resources[0];
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+
+    // sumbar values (left and right)
+    expect(screen.getByText("10/10")).toBeInTheDocument();
+    expect(screen.getByText("90/90")).toBeInTheDocument();
+    // zone-a and zone-b (left and right)
+    expect(screen.queryAllByText("5/5").length).toEqual(2);
+    expect(screen.queryAllByText("45/45").length).toEqual(2);
+    // zone-c does not contain commitments and displays the basic bar layout.
+    expect(screen.getByText(/no quota/i)).toBeInTheDocument();
   });
 });

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -45,7 +45,7 @@ import { initialCommitmentObject, TransferStatus } from "../../lib/constants";
 
 const EditPanel = (props) => {
   const { scope } = globalStore();
-  const { serviceType, currentResource, currentCategory, subRoute } = { ...props };
+  const { serviceType, currentResource, currentCategory, subRoute, tracksQuota } = { ...props };
   const resourceName = currentResource.name;
   const minConfirmDate = currentResource?.commitment_config?.min_confirm_by;
   const [canConfirm, setCanConfirm] = React.useState(null);
@@ -365,6 +365,7 @@ const EditPanel = (props) => {
         subRoute={subRoute}
         setIsMerging={setIsMerging}
         setCurrentAZ={setCurrentAZ}
+        tracksQuota={tracksQuota}
       />
       <div className={"sticky top-0 z-[100] bg-juno-grey-light-1 h-8"}>
         {toast.message && (

--- a/src/components/panel/PanelManager.js
+++ b/src/components/panel/PanelManager.js
@@ -18,7 +18,7 @@ import React from "react";
 import { Panel } from "@cloudoperators/juno-ui-components";
 import EditPanel from "./EditPanel";
 import { useParams, useNavigate, useLocation } from "react-router";
-import { t } from "../../lib/utils";
+import { t, getCurrentResource } from "../../lib/utils";
 import { initialCommitmentObject } from "../../lib/constants";
 import { createCommitmentStore, createCommitmentStoreActions, domainStoreActions, globalStore } from "../StoreProvider";
 
@@ -27,8 +27,11 @@ const PanelManager = (props) => {
   const location = useLocation();
   const params = useParams();
   const navigate = useNavigate();
-  const { resource: currentResource, serviceType, tracksQuota } = {...location.state}
+  const { serviceType, tracksQuota } = {...location.state}
   const { currentArea, categoryName, resourceName, subRoute } = { ...params };
+  // currentResource has to be provided from the props. The location state is static and does not refresh on rerender once the project data gets requeried.
+  const { resources } = props.categories[categoryName];
+  const currentResource = getCurrentResource(resources, resourceName);
   const { setShowCommitments } = domainStoreActions();
   const { isEditing } = createCommitmentStore();
   const { currentProject } = createCommitmentStore();

--- a/src/components/panel/PanelManager.js
+++ b/src/components/panel/PanelManager.js
@@ -17,13 +17,18 @@
 import React from "react";
 import { Panel } from "@cloudoperators/juno-ui-components";
 import EditPanel from "./EditPanel";
-import { useParams, useNavigate } from "react-router";
-import { t, getCurrentResource } from "../../lib/utils";
+import { useParams, useNavigate, useLocation } from "react-router";
+import { t } from "../../lib/utils";
 import { initialCommitmentObject } from "../../lib/constants";
 import { createCommitmentStore, createCommitmentStoreActions, domainStoreActions, globalStore } from "../StoreProvider";
 
 // Panel needs to be rendered first to enable the fading UI animation.
 const PanelManager = (props) => {
+  const location = useLocation();
+  const params = useParams();
+  const navigate = useNavigate();
+  const { resource: currentResource, serviceType, tracksQuota } = {...location.state}
+  const { currentArea, categoryName, resourceName, subRoute } = { ...params };
   const { setShowCommitments } = domainStoreActions();
   const { isEditing } = createCommitmentStore();
   const { currentProject } = createCommitmentStore();
@@ -40,12 +45,6 @@ const PanelManager = (props) => {
   const { setShowConversionOption } = createCommitmentStoreActions();
   const { setTransferProject } = createCommitmentStoreActions();
   const { setDeleteCommitment } = createCommitmentStoreActions();
-  const navigate = useNavigate();
-  const params = useParams();
-  const { currentArea, categoryName, resourceName, subRoute } = { ...params };
-  const { serviceType } = props.categories[categoryName];
-  const { resources } = props.categories[categoryName];
-  const currentResource = getCurrentResource(resources, resourceName);
 
   React.useEffect(() => {
     if (currentResource) {
@@ -102,6 +101,7 @@ const PanelManager = (props) => {
           currentArea={currentArea}
           currentCategory={categoryName}
           subRoute={subRoute}
+          tracksQuota={tracksQuota}
         />
       </Panel>
     )

--- a/src/components/panel/PanelManager.js
+++ b/src/components/panel/PanelManager.js
@@ -21,13 +21,14 @@ import { useParams, useNavigate, useLocation } from "react-router";
 import { t, getCurrentResource } from "../../lib/utils";
 import { initialCommitmentObject } from "../../lib/constants";
 import { createCommitmentStore, createCommitmentStoreActions, domainStoreActions, globalStore } from "../StoreProvider";
+import { ErrorBoundary } from "../../lib/ErrorBoundary";
 
 // Panel needs to be rendered first to enable the fading UI animation.
 const PanelManager = (props) => {
   const location = useLocation();
   const params = useParams();
   const navigate = useNavigate();
-  const { serviceType, tracksQuota } = {...location.state}
+  const { serviceType, tracksQuota } = { ...location.state };
   const { currentArea, categoryName, resourceName, subRoute } = { ...params };
   // currentResource has to be provided from the props. The location state is static and does not refresh on rerender once the project data gets requeried.
   const { resources } = props.categories[categoryName];
@@ -97,15 +98,17 @@ const PanelManager = (props) => {
         closeable={true}
         heading={`Manage Committed Resources: ${t(categoryName)} - ${t(resourceName)}`}
       >
-        <EditPanel
-          {...props}
-          serviceType={serviceType}
-          currentResource={currentResource}
-          currentArea={currentArea}
-          currentCategory={categoryName}
-          subRoute={subRoute}
-          tracksQuota={tracksQuota}
-        />
+        <ErrorBoundary>
+          <EditPanel
+            {...props}
+            serviceType={serviceType}
+            currentResource={currentResource}
+            currentArea={currentArea}
+            currentCategory={categoryName}
+            subRoute={subRoute}
+            tracksQuota={tracksQuota}
+          />
+        </ErrorBoundary>
       </Panel>
     )
   );

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -16,7 +16,7 @@
 
 import React from "react";
 import ResourceBar from "./ResourceBar";
-import { Unit, valueWithUnit } from "../../lib/unit";
+import { Unit } from "../../lib/unit";
 import { globalStore } from "../StoreProvider";
 
 const ResourceBarBuilder = (props) => {
@@ -66,10 +66,10 @@ const ResourceBarBuilder = (props) => {
   // isPanelView is used, because tracksQuota check is not accessible from EditPanel (gets prop passed from Category)
   return (
     <ResourceBar
-      fillLabel={valueWithUnit(showCommitmentOrUsage, unit)}
-      capacityLabel={valueWithUnit(capacity, unit)}
-      extraFillLabel={valueWithUnit(extraFillValue, unit)}
-      extraCapacityLabel={valueWithUnit(extraCapacityValue, unit)}
+      fillLabel={unit.format(showCommitmentOrUsage)}
+      capacityLabel={unit.format(capacity)}
+      extraFillLabel={unit.format(extraFillValue)}
+      extraCapacityLabel={unit.format(extraCapacityValue, unit)}
       usageLabel={paygView ? "" : clusterView ? "capacity used" : "quota used"}
       fill={usage}
       capacity={capacity}

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -59,9 +59,6 @@ const ResourceBarBuilder = (props) => {
   }
   const quotaOrUsage = tracksQuota ? quota : usage;
   let extraCapacityValue = quotaOrUsage - commitment;
-  if (extraCapacityValue < 0) {
-    extraCapacityValue = 0;
-  }
 
   // isPanelView is used, because tracksQuota check is not accessible from EditPanel (gets prop passed from Category)
   return (

--- a/src/lib/ErrorBoundary.js
+++ b/src/lib/ErrorBoundary.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { Message } from "@cloudoperators/juno-ui-components/index";
+
+export class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error: error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error(error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <Message variant="error">{this.state.error.toString()}</Message>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -374,7 +374,9 @@ function getQuotaNewOrOldModel(res) {
   res.per_az.forEach((az) => {
     return (quotaSum += az[1].quota || 0);
   });
-  res.quota = quotaSum;
+  if (quotaSum > 0) {
+    res.quota = quotaSum;
+  }
 }
 
 // Sum up all commitments of a resource over all AZ's


### PR DESCRIPTION
During https://github.com/sapcc/LimesUI/pull/49 there was an oversight that resulted in tracksQuota being removed from the PanelManager. To detect this missing value, which is cruical to differentiate between usage only and quota tracking resources, a error boundary is introduced. 
A boundary allows us to fail loudly if this property is missing. If it is, it is quite hard to detect otherwise.

Additionally to that, I noticed that the quota display for usage only resources were broken, because the project data parser added a quota value, while `tracksQuota` expects an omitted value.
I added unit tests for both types of resources with or without commitments.

This is also the gorundwork to declutter the rather spreaded value gathering to display the resource bar values. This will be a seperate fix.