### PR TITLE
Add sortable table headers

### DIFF
--- a/src/components/commitment/CommitmentTable.js
+++ b/src/components/commitment/CommitmentTable.js
@@ -15,14 +15,9 @@
  */
 
 import React from "react";
-import {
-  DataGrid,
-  DataGridHeadCell,
-  DataGridRow,
-  IntroBox,
-  LoadingIndicator,
-} from "@cloudoperators/juno-ui-components";
+import { DataGrid, DataGridRow, IntroBox, LoadingIndicator } from "@cloudoperators/juno-ui-components";
 import CommitmentTableDetails from "./CommitmentTableDetails";
+import useSortTableData from "../../hooks/useSortTable";
 import useCommitmentFilter from "../../hooks/useCommitmentFilter";
 import { createCommitmentStore } from "../StoreProvider";
 
@@ -55,15 +50,15 @@ const CommitmentTable = (props) => {
       label: "Starts at",
     },
     {
-      key: "confirmedAt",
+      key: "confirmed_at",
       label: "Confirmed at",
     },
     {
-      key: "expiresAt",
+      key: "expires_at",
       label: "Expires at",
     },
     {
-      key: "requestedBy",
+      key: "creator_name",
       label: "Requester",
     },
     {
@@ -85,6 +80,8 @@ const CommitmentTable = (props) => {
     return filteredData;
   }, [commitmentData, currentAZ, resourceName, isCommitting]);
 
+  const { items, TableSortHeader } = useSortTableData(filteredCommitments);
+
   React.useEffect(() => {
     filteredCommitments.length >= 2 ? setMergeIsActive(true) : setMergeIsActive(false);
   }, [filteredCommitments]);
@@ -95,11 +92,16 @@ const CommitmentTable = (props) => {
     <DataGrid columns={commitmentHeadCells.length} gridColumnTemplate={gridColumnTemplate}>
       <DataGridRow>
         {commitmentHeadCells.map((headCell) => (
-          <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
+          <TableSortHeader
+            key={headCell.key}
+            identifier={headCell.key}
+            value={headCell.label}
+            rule={headCell.keyrule}
+          />
         ))}
       </DataGridRow>
 
-      {filteredCommitments.map((commitment) => (
+      {items.map((commitment) => (
         <CommitmentTableDetails
           key={commitment.id}
           commitment={commitment}

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -20,7 +20,6 @@ import {
   DataGrid,
   DataGridRow,
   DataGridCell,
-  DataGridHeadCell,
   Select,
   SelectOption,
   Stack,
@@ -30,6 +29,7 @@ import RenewModal from "../commitment/Modals/RenewModal";
 import { t, formatTimeISO8160 } from "../../lib/utils";
 import { Unit, valueWithUnit } from "../../lib/unit";
 import { categoryTitle } from "../paygAvailability/stylescss";
+import useSortTableData from "../../hooks/useSortTable";
 import { useMutation } from "@tanstack/react-query";
 import { createCommitmentStoreActions } from "../StoreProvider";
 
@@ -43,7 +43,7 @@ export const missingRole =
   "You are missing the permissions to edit this page. Please forward this page to a resource admin.";
 
 const CommitmentRenewal = (props) => {
-  const { renewable = [], inconsistent = [], canEdit = false } = props;
+  const { renewable = [], inconsistent = [], canEdit = false, sortConfig = [] } = props;
   const hasRenewable = renewable.length > 0;
   const hasInconsistencies = inconsistent.length > 0;
   const [showModal, setShowModal] = React.useState(false);
@@ -54,13 +54,13 @@ const CommitmentRenewal = (props) => {
   const commitmentRenew = useMutation({ mutationKey: ["renewCommitment"] });
   const { setRefetchCommitmentAPI } = createCommitmentStoreActions();
   const headCells = [
-    { key: "Category", label: "Category" },
-    { key: "resourceName", label: "Resource" },
-    { key: "availabilityZone", label: "AZ" },
+    { key: "service_type", label: "Category" },
+    { key: "resource_name", label: "Resource" },
+    { key: "availability_zone", label: "AZ" },
     { key: "amount", label: "Amount" },
     { key: "duration", label: "Duration" },
-    { key: "confirmedAt", label: "Confirmed at" },
-    { key: "expiresAt", label: "Expires at" },
+    { key: "confirmed_at", label: "Confirmed at" },
+    { key: "expires_at", label: "Expires at" },
   ];
   let renewableHeadCells = [...headCells];
   renewableHeadCells.push({ key: "renew", label: "Renew" });
@@ -80,6 +80,15 @@ const CommitmentRenewal = (props) => {
     const result = Object.assign(allCategories, renewableResult);
     return result;
   }, [renewable]);
+
+  const { items: renewableItems, TableSortHeader: RenewableHeader } = useSortTableData(
+    renewablePerService[selectedCategory],
+    sortConfig
+  );
+  const { items: inconistentItems, TableSortHeader: InconstentcyHeader } = useSortTableData(
+    inconsistent,
+    sortConfig
+  );
 
   function onRenewSelectionChange(value) {
     setSelectedCategory(value);
@@ -135,7 +144,7 @@ const CommitmentRenewal = (props) => {
   }
 
   return (
-    <div>
+    <>
       {toast && (
         <Message variant="error" dismissible={true} onDismiss={() => setToast(null)}>
           <span className="whitespace-pre-line">{toast}</span>
@@ -181,10 +190,11 @@ const CommitmentRenewal = (props) => {
           <DataGrid columns={renewableHeadCells.length} className={"mb-10"}>
             <DataGridRow>
               {renewableHeadCells.map((headCell) => (
-                <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
+                <RenewableHeader key={headCell.key} identifier={headCell.key} value={headCell.label} />
               ))}
             </DataGridRow>
-            {renewablePerService[selectedCategory]?.map((c) => {
+
+            {renewableItems.map((c) => {
               return getTableData(c, true);
             })}
           </DataGrid>
@@ -206,10 +216,10 @@ const CommitmentRenewal = (props) => {
           <DataGrid columns={inconsistencyHeadCells.length}>
             <DataGridRow>
               {inconsistencyHeadCells.map((headCell) => (
-                <DataGridHeadCell key={headCell.key}>{headCell.label}</DataGridHeadCell>
+                <InconstentcyHeader key={headCell.key} identifier={headCell.key} value={headCell.label} />
               ))}
             </DataGridRow>
-            {inconsistent.map((c) => {
+            {inconistentItems.map((c) => {
               return getTableData(c, false);
             })}
           </DataGrid>
@@ -223,7 +233,7 @@ const CommitmentRenewal = (props) => {
         commitments={commitmentsForModal.current}
         onModalClose={() => setShowModal(false)}
       />
-    </div>
+    </>
   );
 };
 

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -71,9 +71,15 @@ const RenewalManager = (props) => {
     }
     return 0;
   }
+  const initialSortConfig = { service_type: "ascending", expires_at: "ascending" };
 
   return (
-    <CommitmentRenewal canEdit={canEdit} renewable={renewableCommitments} inconsistent={inconsistentCommitments} />
+    <CommitmentRenewal
+      canEdit={canEdit}
+      renewable={renewableCommitments}
+      inconsistent={inconsistentCommitments}
+      sortConfig={initialSortConfig}
+    />
   );
 };
 

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -135,7 +135,7 @@ const Resource = (props) => {
           distribution={!editableResource && !isPanelView && "between"}
         >
           {displayName}
-          {scope.isProject() && (
+          {canEdit && scope.isProject() && (
             <span className="font-light">
               <MaxQuota {...maxQuotaForwardProps} />
             </span>

--- a/src/components/mainView/Resource.test.js
+++ b/src/components/mainView/Resource.test.js
@@ -48,7 +48,7 @@ describe("Resource tests", () => {
       editableResource: false,
       per_az: [["az1", { projects_usage: 10 }]],
     };
-    const forwardProps = {
+    let forwardProps = {
       area: "testArea",
       canEdit: true,
       categoryName: "testCategory",
@@ -75,12 +75,23 @@ describe("Resource tests", () => {
         { wrapper }
       );
     });
+    
     // Project level
     act(() => {
       result.current.globalStoreActions.setScope(scope);
     });
+    // resource does not allow commitments, therfore the maxQuota edit option should be displayed.
     expect(screen.getByTestId("maxQuotaEdit")).toBeInTheDocument();
-    // resource does not allow commitments
+    // edit option should not be invisible if no edit previleges are present
+    forwardProps = { ...forwardProps, canEdit: false };
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+    expect(screen.queryByTestId("maxQuotaEdit")).not.toBeInTheDocument();
+    forwardProps = { ...forwardProps, canEdit: true };
+    rerender();
+    // resource allows commitments, therefore the maxQuota edit option should not be displayed.
     res.editableResource = true;
     rerender();
     act(() => {

--- a/src/hooks/useSortTable.js
+++ b/src/hooks/useSortTable.js
@@ -1,0 +1,69 @@
+import React from "react";
+import { useState } from "react";
+import { t } from "../lib/utils";
+import { DataGridHeadCell, Icon, Stack } from "@cloudoperators/juno-ui-components/index";
+
+const useSortTableData = (items, config = null) => {
+  const [sortConfig, setSortConfig] = useState(config || {});
+
+  console.log(sortConfig)
+
+  const sortedItems = React.useMemo(() => {
+    if (Object.keys(sortConfig).length === 0) return items;
+    const [[key, direction]] = Object.entries(sortConfig);
+
+    return [...items].sort((a, b) => {
+      if (t(a[key]) < t(b[key])) {
+        return direction === "ascending" ? -1 : 1;
+      }
+      if (t(a[key]) > t(b[key])) {
+        return direction === "descending" ? -1 : 1;
+      }
+      return 0;
+    });
+  }, [items, sortConfig]);
+
+  const requestSort = (key) => {
+    setSortConfig((currentConfig) => {
+      const currentDirection = currentConfig[key];
+      let direction = "ascending";
+      if (currentDirection === "ascending") {
+        direction = "descending";
+      }
+      const newConfig = { [key]: direction };
+      return newConfig;
+    });
+  };
+
+  const TableSortHeader = (headerProps) => {
+    const { value = "", identifier = "" } = headerProps;
+    const direction = sortConfig[identifier];
+    const isIdentifierInItems = items.some((item) => {
+      return item[identifier];
+    });
+
+    return (
+      <DataGridHeadCell>
+        {isIdentifierInItems ? (
+          <Stack>
+            {value}
+            <Icon
+              onClick={() => {
+                requestSort(identifier);
+              }}
+              title={direction ?? "sort"}
+              icon={
+                direction === "ascending" ? "expandLess" : direction === "descending" ? "expandMore" : "chevronRight"
+              }
+            />
+          </Stack>
+        ) : (
+          <>{value}</>
+        )}
+      </DataGridHeadCell>
+    );
+  };
+  return { items: sortedItems, requestSort, sortConfig, TableSortHeader };
+};
+
+export default useSortTableData;


### PR DESCRIPTION
This PR adds sortable table headers to renewable commitments and to the commitment table within the `EditPanel`.
This also fixes an oversight where maxQuota edits could be visble without `canEdit` permissions. A unit test is included.

TODOS:
- [ ] fix issue that a table key could have multiple values. For example the `Starts At` column can either be "confirm_by" or "created_at"
- [ ] Add unit tests for the custom hook.