### PR TITLE
fix: negative value with unit

### DIFF
--- a/src/lib/unit.js
+++ b/src/lib/unit.js
@@ -79,6 +79,10 @@ export class Unit {
   format(value, options = {}) {
     //convert value into bigger units if available
     let steps = this.unitData.steps;
+
+    const prefix = value < 0 && "-";
+    value = Math.abs(value);
+
     while (value >= this.scaleData.step && steps + 1 < this.scaleData.prefixes.length) {
       value /= this.scaleData.step;
       steps += 1;
@@ -93,7 +97,7 @@ export class Unit {
     } else {
       //if possible, join with narrow no-break space instead of regular space
       const space = options.ascii ? " " : "\u202F";
-      return value + space + displayUnit;
+      return prefix + value + space + displayUnit;
     }
   }
 

--- a/src/lib/unit.test.js
+++ b/src/lib/unit.test.js
@@ -55,6 +55,18 @@ describe("Unit", () => {
       }
     });
   });
+  it("renders negative values", () => {
+    let cases = [
+      [-1, /^-1\sMiB$/],
+      [-1234, /^-1.21\sGiB$/],
+      [-45421, /^-44.36\sGiB$/],
+      [-1234567, /^-1.18\sTiB$/],
+    ];
+    const u = new Unit("MiB");
+    for (const [input, output] of cases) {
+      expect(u.format(input)).toMatch(output);
+    }
+  });
 
   describe(".parse", () => {
     const errSyntax = { error: "syntax" };


### PR DESCRIPTION
Because we now allow the remaining resource bar to have negative values if "0" values get reported (see: https://github.com/sapcc/LimesUI/pull/55),
we discovered a bug where the unit parser would not transform the value to its display equivalent properly. It would rather display the value with the same unit that gets provided by the API.

Here is how it looks like now:
<img width="539" alt="image" src="https://github.com/user-attachments/assets/8ec262e6-5de6-4d39-9403-a97c78f3f068" />
