### PR TITLE
fix: maxQuota edit display option in panel

### DIFF
--- a/.changeset/sad-rings-remain.md
+++ b/.changeset/sad-rings-remain.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+fix: max quota edit option to be available in the panel again

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -113,7 +113,7 @@ const Resource = (props) => {
   }
 
   const maxQuotaForwardProps = {
-    editMode: isPanelView || !editableResource,
+    editMode: isPanelView || (canEdit && !editableResource),
     project: project,
     resource: resource,
     serviceType: serviceType,
@@ -135,7 +135,7 @@ const Resource = (props) => {
           distribution={!editableResource && !isPanelView && "between"}
         >
           {displayName}
-          {canEdit && scope.isProject() && (
+          {scope.isProject() && (
             <span className="font-light">
               <MaxQuota {...maxQuotaForwardProps} />
             </span>

--- a/src/components/panel/EditPanel.test.js
+++ b/src/components/panel/EditPanel.test.js
@@ -120,6 +120,9 @@ describe("EditPanel tests", () => {
 
     const selectedAZ = screen.getByTestId("tab/az1");
     expect(selectedAZ).toHaveAttribute("aria-selected", "true");
+
+    // expect maxQuota edit to be available
+    expect(screen.getByTestId("maxQuotaEdit")).toBeInTheDocument();
   });
 
   test("Commitment merging", async () => {


### PR DESCRIPTION
The max-edit option was not available in the edit panel.
The panel provides the option `isPanelView` while the resource card determines the availability of the max edit option with the resource edit permission `canEdit`. A unit test now checks the panel as well.