### PR TITLE
Additional QoL updates

### DIFF
--- a/.changeset/tall-emus-stop.md
+++ b/.changeset/tall-emus-stop.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": minor
+---
+
+Domain/Cluster level: Add project filtering by label. Improve clearance for commitment transfer"

--- a/src/components/commitment/CommitmentTable.js
+++ b/src/components/commitment/CommitmentTable.js
@@ -28,6 +28,7 @@ const CommitmentTable = (props) => {
   const { filterCommitments } = useCommitmentFilter();
   const { commitment: newCommitment } = createCommitmentStore();
   const { commitmentIsFetching } = createCommitmentStore();
+  const commitmentTransferID = React.useRef(null);
   const { isCommitting } = createCommitmentStore();
   const { serviceType, currentCategory, currentResource, currentAZ, commitmentData, mergeOps } = {
     ...props,
@@ -127,6 +128,7 @@ const CommitmentTable = (props) => {
           currentCategory={currentCategory}
           currentResource={currentResource}
           currentAZ={currentAZ}
+          commitmentTransferID={commitmentTransferID}
           mergeOps={mergeOps}
         />
       ))}

--- a/src/components/commitment/CommitmentTableDetails.js
+++ b/src/components/commitment/CommitmentTableDetails.js
@@ -26,8 +26,13 @@ import { initialCommitmentObject } from "../../lib/constants";
 import { COMMITMENTID } from "../../lib/constants";
 import useResetCommitment from "../../hooks/useResetCommitment";
 
+const transferLabel = Object.freeze({
+  Move: "Move",
+  Selected: "Selected",
+});
+
 const CommitmentTableDetails = (props) => {
-  const { commitment, mergeOps } = props;
+  const { commitment, commitmentTransferID, mergeOps } = props;
   const {
     id,
     amount,
@@ -221,17 +226,20 @@ const CommitmentTableDetails = (props) => {
           <Stack gap="2">
             <Button
               size="small"
+              title={commitment.id == commitmentTransferID.current && `Please select a target project`}
               variant="primary"
               onClick={() => {
+                commitmentTransferID.current = commitment.id;
                 transferCommit();
               }}
               disabled={newCommitment?.id == id}
             >
-              Move
+              {commitment.id == commitmentTransferID.current ? transferLabel.Selected : transferLabel.Move}
             </Button>
             <Button
               size="small"
               onClick={() => {
+                commitmentTransferID.current = null;
                 resetCommitmentTransfer();
               }}
             >

--- a/src/components/domain/DomainManager.js
+++ b/src/components/domain/DomainManager.js
@@ -20,7 +20,7 @@ import { clusterStore, clusterStoreActions } from "../StoreProvider";
 import ProjectsPerDomain from "./ProjectsPerDomain";
 
 const DomainManager = (props) => {
-  const { serviceType, currentCategory, currentResource, currentAZ, subRoute, mergeOps } = props;
+  const { serviceType, currentCategory, currentResource, currentAZ, subRoute, sortProjectProps, mergeOps } = props;
   const { domainData } = clusterStore();
   const { setDomainData } = clusterStoreActions();
   const domainQueryResult = useQuery({ queryKey: ["domains", "", ""] });
@@ -43,6 +43,7 @@ const DomainManager = (props) => {
         currentCategory={currentCategory}
         currentAZ={currentAZ}
         subRoute={subRoute}
+        sortProjectProps={sortProjectProps}
         mergeOps={mergeOps}
       />
     )

--- a/src/components/domain/ProjectsPerDomain.js
+++ b/src/components/domain/ProjectsPerDomain.js
@@ -44,6 +44,7 @@ const ProjectsPerDomain = (props) => {
   const isLoading = projectQueries.some((query) => query.isLoading);
   // Refetches change the fetchStatus not the loading status.
   const isFetching = projectQueries.some((query) => query.isFetching);
+  const refetchTriggered = React.useRef(false);
   const { setRefetchProjectAPI } = projectStoreActions();
   const { refetchProjectAPI } = projectStore();
   const sortProjects = React.useRef(true);
@@ -71,7 +72,8 @@ const ProjectsPerDomain = (props) => {
         return project;
       })
     );
-    if (projects?.length > 0) {
+    if (projects?.length > 0 && refetchTriggered.current) {
+      refetchTriggered.current = false;
       enableSortActivities();
     }
     setProjects(flattendProjects, sortProjects.current);
@@ -82,6 +84,7 @@ const ProjectsPerDomain = (props) => {
     if (!refetchProjectAPI) return;
     setRefetchProjectAPI(false);
     sortProjects.current = false;
+    refetchTriggered.current = true;
     projectQueries.forEach((query) => {
       query.refetch();
     });

--- a/src/components/domain/ProjectsPerDomain.js
+++ b/src/components/domain/ProjectsPerDomain.js
@@ -29,7 +29,8 @@ import { LoadingIndicator } from "@cloudoperators/juno-ui-components";
 
 const ProjectsPerDomain = (props) => {
   // Fetch project data for all domains
-  const { domains, serviceType, currentCategory, resource, currentAZ, subRoute, mergeOps } = props;
+  const { domains, serviceType, currentCategory, resource, currentAZ, subRoute, sortProjectProps, mergeOps } = props;
+  const { enableSortActivities } = sortProjectProps;
   const resourceName = resource.name;
   const { restructureReport } = globalStoreActions();
   const { setProjectsToDomain } = clusterStoreActions();
@@ -70,6 +71,9 @@ const ProjectsPerDomain = (props) => {
         return project;
       })
     );
+    if (projects?.length > 0) {
+      enableSortActivities();
+    }
     setProjects(flattendProjects, sortProjects.current);
     projectsUpdated.current = true;
   }, [isFetching]);
@@ -91,6 +95,7 @@ const ProjectsPerDomain = (props) => {
       currentAZ={currentAZ}
       projects={projects}
       subRoute={subRoute}
+      sortProjectProps={sortProjectProps}
       mergeOps={mergeOps}
     />
   ) : (

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -86,6 +86,7 @@ const EditPanel = (props) => {
   const { setCommitmentIsLoading } = createCommitmentStoreActions();
   const conversionResults = useGetConversions({ serviceType, resourceName });
   const [currentAZ, setCurrentAZ] = React.useState(currentResource.per_az[0].name);
+  const [projectsAreSortable, setProjectsAreSortable] = React.useState(false);
   // Merge Commitments
   const [commitmentsToMerge, setCommitmentsToMerge] = React.useState([]);
   // The merge button is active if >= 2 commitments are available for the AZ.
@@ -132,6 +133,14 @@ const EditPanel = (props) => {
     );
   }, [isSubmitting]);
 
+  function enableSortActivities() {
+    if (!scope.isProject()) {
+      setToast("Order of projects might have updated. Please sort the table.", "info");
+      setProjectsAreSortable(true);
+    }
+  }
+  const sortProjectProps = { projectsAreSortable, setProjectsAreSortable, enableSortActivities };
+
   function postCommitment(confirm_by = null, notifyOnConfirm = false) {
     const currentProjectID = currentProject?.metadata?.id;
     const currentDomainID = scope.isCluster() ? currentProject.metadata.domainID : null;
@@ -143,8 +152,6 @@ const EditPanel = (props) => {
       { payload: { commitment: payload }, queryKey: [currentProjectID, currentDomainID] },
       {
         onSuccess: () => {
-          (scope.isDomain() || scope.isCluster()) &&
-            setToast("Order of projects might have updated. Please sort the table.", "info");
           setRefetchClusterAPI(true);
           setRefetchDomainAPI(true);
           setRefetchProjectAPI(true);
@@ -212,7 +219,6 @@ const EditPanel = (props) => {
       },
       {
         onSuccess: () => {
-          !scope.isProject() && setToast("Order of projects might have updated. Please sort the table.", "info");
           resetCommitmentTransfer();
           setRefetchClusterAPI(true);
           setRefetchDomainAPI(true);
@@ -400,6 +406,7 @@ const EditPanel = (props) => {
           currentResource={currentResource}
           currentAZ={currentAZ}
           subRoute={subRoute}
+          sortProjectProps={sortProjectProps}
           mergeOps={mergeForwardProps}
         />
       )}
@@ -410,6 +417,7 @@ const EditPanel = (props) => {
           currentResource={currentResource}
           currentAZ={currentAZ}
           subRoute={subRoute}
+          sortProjectProps={sortProjectProps}
           mergeOps={mergeForwardProps}
         />
       )}

--- a/src/components/panel/PanelManager.js
+++ b/src/components/panel/PanelManager.js
@@ -21,7 +21,7 @@ import { tracksQuota } from "../../lib/utils";
 import { useParams, useNavigate } from "react-router";
 import { t, getCurrentResource } from "../../lib/utils";
 import { initialCommitmentObject } from "../../lib/constants";
-import { createCommitmentStore, createCommitmentStoreActions, domainStoreActions, globalStore } from "../StoreProvider";
+import { createCommitmentStore, createCommitmentStoreActions } from "../StoreProvider";
 import { ErrorBoundary } from "../../lib/ErrorBoundary";
 
 // Panel needs to be rendered first to enable the fading UI animation.
@@ -34,11 +34,7 @@ const PanelManager = (props) => {
   const currentResource = getCurrentResource(resources, resourceName);
   const isEditableResource = currentResource.commitment_config?.durations ?? false;
   const resourceTracksQuota = tracksQuota(currentResource);
-  const { setShowCommitments } = domainStoreActions();
   const { isEditing } = createCommitmentStore();
-  const { currentProject } = createCommitmentStore();
-  const project = React.useRef(currentProject);
-  const { scope } = globalStore();
   const { resetValidDurations } = createCommitmentStoreActions();
   const { setIsEditing } = createCommitmentStoreActions();
   const { setCommitment } = createCommitmentStoreActions();
@@ -60,16 +56,11 @@ const PanelManager = (props) => {
       setIsSubmitting(false);
       setTransferProject(null);
       setDeleteCommitment(null);
-      onPanelClose(project.current);
+      onPanelClose();
     };
   }, [currentResource]);
 
-  // This is a workaround hence the return statement of a useEffect apparently clears the store data first.
-  React.useEffect(() => {
-    project.current = currentProject;
-  }, [currentProject]);
-
-  function onPanelClose(currentProject) {
+  function onPanelClose() {
     setCommitment(initialCommitmentObject);
     setToast(null);
     // create commitment
@@ -80,10 +71,6 @@ const PanelManager = (props) => {
     // transfer commitment
     setTransferCommitment(false);
     setIsTransferring(false);
-    // Reset showCommitment on project
-    if (!scope.isProject() && currentProject) {
-      setShowCommitments(currentProject.metadata.id, false);
-    }
   }
 
   //Durations get checked to avoid route call to uneditable resource.
@@ -93,7 +80,7 @@ const PanelManager = (props) => {
         size="large"
         opened={isEditing}
         onClose={() => {
-          onPanelClose(currentProject);
+          onPanelClose();
           navigate(`/${currentArea}`);
         }}
         closeable={true}

--- a/src/components/project/ProjectManager.js
+++ b/src/components/project/ProjectManager.js
@@ -22,7 +22,8 @@ import { globalStoreActions, domainStoreActions, domainStore } from "../StorePro
 import { LoadingIndicator } from "@cloudoperators/juno-ui-components";
 
 const ProjectManager = (props) => {
-  const { serviceType, currentCategory, currentResource, currentAZ, subRoute, mergeOps } = props;
+  const { serviceType, currentCategory, currentResource, currentAZ, subRoute, sortProjectProps, mergeOps } = props;
+  const { enableSortActivities } = sortProjectProps;
   const resourceName = currentResource.name;
   const { refetchProjectAPI } = projectStore();
   const { setRefetchProjectAPI } = projectStoreActions();
@@ -34,6 +35,7 @@ const ProjectManager = (props) => {
   });
   const { data: projectsInDomain, isLoading } = projectsQueryResult;
   const sortProjects = React.useRef(true);
+  const refetchTriggered = React.useRef(false);
 
   // Fetch project data.
   // Only one project should show commitments at the same time. A variable gets added to the projects.
@@ -43,6 +45,10 @@ const ProjectManager = (props) => {
       return restructureReport(project);
     });
     setProjects(projects, sortProjects.current);
+    if (projects?.length > 0 && refetchTriggered.current) {
+      refetchTriggered.current = false;
+      enableSortActivities();
+    }
     sortProjects.current = true;
   }, [projectsInDomain]);
 
@@ -50,6 +56,7 @@ const ProjectManager = (props) => {
     if (!refetchProjectAPI) return;
     setRefetchProjectAPI(false);
     sortProjects.current = false;
+    refetchTriggered.current = true;
     projectsQueryResult.refetch();
   }, [refetchProjectAPI]);
 
@@ -61,6 +68,7 @@ const ProjectManager = (props) => {
       currentAZ={currentAZ}
       projects={projects}
       subRoute={subRoute}
+      sortProjectProps={sortProjectProps}
       mergeOps={mergeOps}
     />
   ) : (

--- a/src/components/project/ProjectTable.js
+++ b/src/components/project/ProjectTable.js
@@ -166,10 +166,9 @@ const ProjectTable = (props) => {
 
   // Change the displayed projects corresponding to its filtered string
   // The show commitment state will be transferred to filtered projects.
-  function filterProjectsByName() {
+  function filterProjectsByName(projects) {
     const regex = new RegExp(nameFilter.current.trim(), "i");
-    const projectsToFilter = getProjectsToFilter();
-    const filteredProjects = projectsToFilter.filter((project) => {
+    const filteredProjects = projects.filter((project) => {
       const filterName = scope.isCluster() ? project.metadata.fullName : project.metadata.name;
       const projectID = project.metadata.id;
       const matchesNameOrID = regex.exec(filterName) || regex.exec(projectID);
@@ -178,21 +177,14 @@ const ProjectTable = (props) => {
     setFilteredProjects(chunkProjects(filteredProjects));
   }
 
-  function filterProjectsPerAZLabel() {
-    if (labelFilter.current == filterOpts.None) {
-      setFilteredProjects(chunkProjects(projects));
+  function filterProjectsPerNameOrLabel() {
+    const projectsToFilter = getProjectsToFilter();
+    if (nameFilter.current === "") {
+      setFilteredProjects(chunkProjects(projectsToFilter));
     } else {
-      setFilteredProjects(chunkProjects(projectsPerLabel.get(labelFilter.current) || []));
+      filterProjectsByName(projectsToFilter);
     }
     setCurrentPage(0);
-  }
-
-  function filterProjectsPerNameOrLabel() {
-    if (nameFilter.current === "") {
-      filterProjectsPerAZLabel();
-    } else {
-      filterProjectsByName();
-    }
   }
   React.useEffect(() => {
     filterProjectsPerNameOrLabel();
@@ -227,13 +219,11 @@ const ProjectTable = (props) => {
               value={nameFilter.current}
               onChange={(e) => {
                 nameFilter.current = e.target.value;
-                setCurrentPage(0);
-                filterProjectsByName();
+                filterProjectsPerNameOrLabel();
               }}
               onClear={() => {
                 nameFilter.current = "";
-                setCurrentPage(0);
-                setFilteredProjects(chunkProjects(getProjectsToFilter()));
+                filterProjectsPerNameOrLabel();
               }}
             />
             {!subRoute && (

--- a/src/components/project/ProjectTable.js
+++ b/src/components/project/ProjectTable.js
@@ -82,7 +82,8 @@ const filterOpts = Object.freeze({
 
 // Display the project details in DomainView
 const ProjectTable = (props) => {
-  const { serviceType, currentResource, currentCategory, currentAZ, projects, subRoute, mergeOps } = props;
+  const { serviceType, currentResource, currentCategory, currentAZ, projects, subRoute, sortProjectProps, mergeOps } =
+    props;
   const resourceTracksQuota = tracksQuota(currentResource);
   const { scope } = globalStore();
   const [selectedProject, setSelectedProject] = React.useState({ id: "", showCommitments: false });
@@ -94,6 +95,7 @@ const ProjectTable = (props) => {
   const labelFilter = React.useRef(filterOpts.None);
   const nameFilter = React.useRef("");
   const [currentPage, setCurrentPage] = React.useState(0);
+  console.log(sortProjectProps.projectsAreSortable)
 
   if (!resourceTracksQuota && subRoute) return;
 
@@ -221,9 +223,11 @@ const ProjectTable = (props) => {
             />
             {!subRoute && (
               <Button
+                disabled={!sortProjectProps.projectsAreSortable}
                 onClick={() => {
                   setToast(null);
-                  setSortedProjects(projects);
+                  setSortedProjects();
+                  sortProjectProps.setProjectsAreSortable(false);
                 }}
                 className={"m-auto mt-0"}
               >

--- a/src/components/project/ProjectTable.js
+++ b/src/components/project/ProjectTable.js
@@ -95,7 +95,6 @@ const ProjectTable = (props) => {
   const labelFilter = React.useRef(filterOpts.None);
   const nameFilter = React.useRef("");
   const [currentPage, setCurrentPage] = React.useState(0);
-  console.log(sortProjectProps.projectsAreSortable)
 
   if (!resourceTracksQuota && subRoute) return;
 

--- a/src/components/project/ProjectTable.js
+++ b/src/components/project/ProjectTable.js
@@ -77,7 +77,7 @@ const quotaTableHeadCells = [
   },
 ];
 const filterOpts = Object.freeze({
-  None: "none",
+  Any: "any",
 });
 
 // Display the project details in DomainView
@@ -92,7 +92,7 @@ const ProjectTable = (props) => {
   const { setCurrentProject } = createCommitmentStoreActions();
   const { setToast } = createCommitmentStoreActions();
   const [filteredProjects, setFilteredProjects] = React.useState(chunkProjects(projects));
-  const labelFilter = React.useRef(filterOpts.None);
+  const labelFilter = React.useRef(filterOpts.Any);
   const nameFilter = React.useRef("");
   const [currentPage, setCurrentPage] = React.useState(0);
 
@@ -130,7 +130,7 @@ const ProjectTable = (props) => {
     if (subRoute) {
       return { availableLabels: [], projectsPerLabel: new Map() };
     }
-    const uniqueLabels = new Set([filterOpts.None]);
+    const uniqueLabels = new Set([filterOpts.Any]);
     const matchingProjects = new Map();
 
     projects.forEach((project) => {
@@ -154,7 +154,7 @@ const ProjectTable = (props) => {
 
   function getProjectsToFilter() {
     const projectsToFilter =
-      labelFilter.current == filterOpts.None ? projects : projectsPerLabel.get(labelFilter.current) || [];
+      labelFilter.current == filterOpts.Any ? projects : projectsPerLabel.get(labelFilter.current) || [];
     return projectsToFilter;
   }
 
@@ -195,6 +195,7 @@ const ProjectTable = (props) => {
           <Stack gap="1">
             {!subRoute && (
               <Select
+                data-testid="Filter"
                 className="w-40"
                 width="auto"
                 label="Filter"
@@ -210,6 +211,7 @@ const ProjectTable = (props) => {
               </Select>
             )}
             <SearchInput
+              data-testid="Search"
               value={nameFilter.current}
               onChange={(e) => {
                 nameFilter.current = e.target.value;

--- a/src/components/project/ProjectTable.test.js
+++ b/src/components/project/ProjectTable.test.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+import { screen, fireEvent, renderHook, waitFor } from "@testing-library/react";
+import ProjectTable from "./ProjectTable";
+import { PortalProvider } from "@cloudoperators/juno-ui-components/index";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import StoreProvider from "../StoreProvider";
+import {
+  globalStoreActions,
+  createCommitmentStore,
+  createCommitmentStoreActions,
+  clusterStoreActions,
+  domainStoreActions,
+  projectStoreActions,
+} from "../StoreProvider";
+
+const mockProps = {
+  serviceType: "Service1",
+  currentResource: { name: "Resource1" },
+  currentCategory: "Category1",
+  currentAZ: "AZ1",
+  projects: [],
+  sortProjectProps: { projectsAreSortable: true, setProjectsAreSortable: jest.fn() },
+  mergeOps: {},
+};
+
+const queryClient = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+queryClient.setQueryDefaults(["commitmentData"], {
+  queryFn: () => {
+    return;
+  },
+});
+
+describe("ProjectTable", () => {
+  test("renders DataGrid with correct table headers", async () => {
+    const expectedHeaders = ["ProjectName", "Status", "Labels", "Actions"];
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <ProjectTable {...mockProps} />
+            {children}
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+    await waitFor(() => {
+      return renderHook(
+        () => ({
+          globalStoreActions: globalStoreActions(),
+          clusterStoreActions: clusterStoreActions(),
+          domainStoreActions: domainStoreActions(),
+          projectStoreActions: projectStoreActions(),
+          commitmentStore: createCommitmentStore(),
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+
+    expectedHeaders.forEach((header) => {
+      expect(screen.getByText(header)).toBeInTheDocument();
+    });
+  });
+
+  test("handles filtering projects by name and label", async () => {
+    const mockProjects = [
+      {
+        metadata: { id: "1", name: "Project1", fullName: "domain1/Project1" },
+        categories: {
+          [mockProps.currentCategory]: {
+            resources: [
+              {
+                name: mockProps.currentResource.name,
+                per_az: [{ name: mockProps.currentAZ, pending_commitments: { "1 year": 10 } }],
+              },
+            ],
+          },
+        },
+      },
+      {
+        metadata: { id: "2", name: "Project2", fullName: "domain2/Project2" },
+        categories: {
+          [mockProps.currentCategory]: {
+            resources: [{ name: mockProps.currentResource.name, per_az: [{ name: mockProps.currentAZ }] }],
+          },
+        },
+      },
+    ];
+    mockProps.projects = mockProjects;
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <ProjectTable {...mockProps} />
+            {children}
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+
+    await waitFor(() => {
+      return renderHook(
+        () => ({
+          globalStoreActions: globalStoreActions(),
+          clusterStoreActions: clusterStoreActions(),
+          domainStoreActions: domainStoreActions(),
+          projectStoreActions: projectStoreActions(),
+          commitmentStore: createCommitmentStore(),
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+
+    // Simulate selecting a label
+    const filter = screen.getByTestId("Filter");
+    fireEvent.click(filter);
+    const option = screen.getByText("pending");
+    fireEvent.click(option);
+    await waitFor(() => {
+      expect(screen.getByText("domain1/Project1")).toBeInTheDocument();
+      expect(screen.queryByText("domain2/Project2")).not.toBeInTheDocument();
+    });
+
+    // Simulate project search by name
+    fireEvent.change(screen.getByTestId("Search"), { target: { value: "project1" } });
+    expect(screen.getByText("domain1/Project1")).toBeInTheDocument();
+    expect(screen.queryByText("domain2/Project2")).not.toBeInTheDocument();
+
+    // Clear the select filter
+    fireEvent.click(filter);
+    const option2 = screen.getByText("any");
+    fireEvent.click(option2);
+    await waitFor(() => {
+      expect(screen.getByText("domain1/Project1")).toBeInTheDocument();
+      expect(screen.queryByText("domain2/Project2")).not.toBeInTheDocument();
+    });
+
+    // Clear the name filter
+    fireEvent.change(screen.getByTestId("Search"), { target: { value: "" } });
+    expect(screen.getByText("domain1/Project1")).toBeInTheDocument();
+    expect(screen.queryByText("domain2/Project2")).toBeInTheDocument();
+  });
+});

--- a/src/components/project/ProjectTable.test.js
+++ b/src/components/project/ProjectTable.test.js
@@ -158,5 +158,10 @@ describe("ProjectTable", () => {
     fireEvent.change(screen.getByTestId("Search"), { target: { value: "" } });
     expect(screen.getByText("domain1/Project1")).toBeInTheDocument();
     expect(screen.queryByText("domain2/Project2")).toBeInTheDocument();
+
+    // enforce an empty list
+    fireEvent.change(screen.getByTestId("Search"), { target: { value: "invalidSearchName" } });
+    expect(screen.queryByText("domain1/Project1")).not.toBeInTheDocument();
+    expect(screen.queryByText("domain2/Project2")).not.toBeInTheDocument();
   });
 });

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -119,8 +119,9 @@ const limesStore = (set, get) => ({
 
         return sortedProjects;
       },
-      setSortedProjects: (projects) =>
+      setSortedProjects: () =>
         set((state) => {
+          const projects = state.domain.projects;
           const sortedProjects = state.domain.actions.sortProjects([...projects]);
           return {
             ...state,

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -55,9 +55,6 @@ const limesStore = (set, get) => ({
     domainData: null,
     refetchDomainAPI: false,
     projects: null,
-    // previous project in detail view. Displays commitments.
-    // Used to close the detailed view if another projects enters its detail mode.
-    previousProject: null,
     actions: {
       setDomainData: (domainData) =>
         set((state) => ({
@@ -67,18 +64,14 @@ const limesStore = (set, get) => ({
         set((state) => ({
           domain: { ...state.domain, refetchDomainAPI: refetchDomainAPI },
         })),
-      setPreviousProject: (previousProject) =>
-        set((state) => ({
-          domain: { ...state.domain, previousProject: previousProject },
-        })),
       setProjects: (projects, sortProjects = true) =>
         set((state) => {
+          const domainProjects = [...(state.domain.projects || [])];
           // The user sorts manually if commitments are added or moved to/from projects.
           if (sortProjects) {
             projects = state.domain.actions.sortProjects(projects);
           } else {
             // Keep previous order structure.
-            const domainProjects = [...state.domain.projects];
             projects.sort((a, b) => {
               return (
                 domainProjects.findIndex((p) => p.metadata.id == a.metadata.id) -
@@ -86,18 +79,6 @@ const limesStore = (set, get) => ({
               );
             });
           }
-
-          // Append the previous showCommitments state to the fresh API data.
-          projects.forEach((project) => {
-            if (state.domain.projects) {
-              const previousProjectIndex = state.domain.projects.findIndex(
-                (oldProject) => project.metadata.id == oldProject.metadata.id
-              );
-              project.showCommitments = state.domain.projects[previousProjectIndex]?.showCommitments || false;
-            } else {
-              project.showCommitments = false;
-            }
-          });
 
           return {
             ...state,
@@ -144,16 +125,6 @@ const limesStore = (set, get) => ({
           return {
             ...state,
             domain: { ...state.domain, projects: sortedProjects },
-          };
-        }),
-      setShowCommitments: (projectID, value) =>
-        set((state) => {
-          const projects = [...state.domain.projects];
-          const index = projects.findIndex((project) => project.metadata.id == projectID);
-          projects[index].showCommitments = value;
-          return {
-            ...state,
-            domain: { ...state.domain, projects: projects },
           };
         }),
     },


### PR DESCRIPTION
This PR includes

- [x] Filter projects by labels and/or name on domain/cluster label
- [x] Only enable the sort button on domain/custer level if a order changing action was performed
- [x] Improving the commitments transfer button layout on domain/cluster level

<img width="540" alt="image" src="https://github.com/user-attachments/assets/7cdb3a27-76ab-41d6-8bc3-e5aa401a8595" />

The user is able to sort per label and/or per project name/id.
The sort button only enables if the user participates in an action that might cause a reorder of the table contents.

<img width="213" alt="image" src="https://github.com/user-attachments/assets/c9a722ec-aee2-4761-968a-b69f63b32676" />

Transfer on domain/cluster level now explicitly tells the user which commitment is selected.
