### PR TITLE
QoL updates

### DIFF
--- a/.changeset/tricky-maps-tap.md
+++ b/.changeset/tricky-maps-tap.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": minor
+---
+
+Add explanatory info segments for resources and availability zones. Make base quota easier to understand.

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -18,7 +18,7 @@ import React from "react";
 import { globalStore, createCommitmentStore } from "../StoreProvider";
 import { t } from "../../lib/utils";
 import { CustomZones, PanelType } from "../../lib/constants";
-import { Stack, Button } from "@cloudoperators/juno-ui-components";
+import { Button, Icon, Stack } from "@cloudoperators/juno-ui-components";
 import { Link } from "react-router";
 import { ProjectBadges } from "../shared/LimesBadges";
 import { isAZUnaware } from "../../lib/utils";
@@ -87,6 +87,8 @@ const Resource = (props) => {
   const displayName = t(resource.name);
   const { isEditing } = createCommitmentStore();
   const { resetCommitment } = useResetCommitment();
+  const [displayResourceInfo, setDisplayResourceInfo] = React.useState(false);
+  const resourceHasQuota = resource?.quota > 0;
 
   const maxQuotaForwardProps = {
     editMode: isPanelView || (canEdit && !editableResource),
@@ -110,7 +112,17 @@ const Resource = (props) => {
           gap="1"
           distribution={canEdit && !editableResource && "between"}
         >
-          {displayName}
+          <Stack>
+            {displayName}
+            {resourceHasQuota && !isPanelView && (
+              <Icon
+                icon={displayResourceInfo ? "expandMore" : "chevronRight"}
+                onClick={() => {
+                  setDisplayResourceInfo(!displayResourceInfo);
+                }}
+              />
+            )}
+          </Stack>
           {scope.isProject() && (
             <span className="font-light">
               <MaxQuota {...maxQuotaForwardProps} />
@@ -154,6 +166,7 @@ const Resource = (props) => {
         barType={"total"}
         isEditableResource={editableResource}
         showToolTip={!isEditing || isPanelView}
+        displayResourceInfo={displayResourceInfo}
       />
       {isAZUnaware(props.resource.per_az) && <PhysicalUsage resource={props.resource} unit={unitName} />}
       <div className={props.isPanelView && `az-container ${azPanelContent} ${props.isPanelView && "gap-2"}`}>
@@ -188,6 +201,7 @@ const Resource = (props) => {
                   unit={unitName}
                   barType={"granular"}
                   isEditableResource={editableResource}
+                  displayResourceInfo={displayResourceInfo}
                 />
                 <PhysicalUsage resource={az} resourceName={props.resource.name} unit={unitName} />
               </div>

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -183,6 +183,7 @@ const Resource = (props) => {
                   <ProjectBadges az={az} unit={unitName} displayValues={true} />
                 </div>
                 <ResourceBarBuilder
+                  parent={resource}
                   resource={az}
                   unit={unitName}
                   barType={"granular"}

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -116,7 +116,9 @@ const Resource = (props) => {
             {displayName}
             {resourceHasQuota && !isPanelView && (
               <Icon
+                data-testid="detailedResourceInfo"
                 icon={displayResourceInfo ? "expandMore" : "chevronRight"}
+                title={displayResourceInfo ? "hide info" : "display info"}
                 onClick={() => {
                   setDisplayResourceInfo(!displayResourceInfo);
                 }}

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -15,7 +15,7 @@
  */
 
 import React from "react";
-import { globalStore } from "../StoreProvider";
+import { globalStore, createCommitmentStore } from "../StoreProvider";
 import { t } from "../../lib/utils";
 import { CustomZones, PanelType } from "../../lib/constants";
 import { Stack, Button } from "@cloudoperators/juno-ui-components";
@@ -85,6 +85,7 @@ const Resource = (props) => {
   const { unit: unitName, editableResource } = resource;
   const { scope } = globalStore();
   const displayName = t(resource.name);
+  const { isEditing } = createCommitmentStore();
   const { resetCommitment } = useResetCommitment();
 
   const maxQuotaForwardProps = {
@@ -147,7 +148,13 @@ const Resource = (props) => {
           </Stack>
         )}
       </Stack>
-      <ResourceBarBuilder resource={resource} unit={unitName} barType={"total"} isEditableResource={editableResource} />
+      <ResourceBarBuilder
+        resource={resource}
+        unit={unitName}
+        barType={"total"}
+        isEditableResource={editableResource}
+        showToolTip={!isEditing || isPanelView}
+      />
       {isAZUnaware(props.resource.per_az) && <PhysicalUsage resource={props.resource} unit={unitName} />}
       <div className={props.isPanelView && `az-container ${azPanelContent} ${props.isPanelView && "gap-2"}`}>
         {props.resource.per_az?.map((az) => {

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -196,8 +196,8 @@ const Resource = (props) => {
                   <ProjectBadges az={az} unit={unitName} displayValues={true} />
                 </div>
                 <ResourceBarBuilder
-                  parent={resource}
-                  resource={az}
+                  resource={resource}
+                  az={az}
                   unit={unitName}
                   barType={"granular"}
                   isEditableResource={editableResource}

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -161,6 +161,7 @@ const Resource = (props) => {
         )}
       </Stack>
       <ResourceBarBuilder
+        scope={scope}
         resource={resource}
         unit={unitName}
         barType={"total"}
@@ -196,6 +197,7 @@ const Resource = (props) => {
                   <ProjectBadges az={az} unit={unitName} displayValues={true} />
                 </div>
                 <ResourceBarBuilder
+                  scope={scope}
                   resource={resource}
                   az={az}
                   unit={unitName}

--- a/src/components/mainView/subComponents/MaxQuota.js
+++ b/src/components/mainView/subComponents/MaxQuota.js
@@ -38,7 +38,7 @@ const MaxQuota = (props) => {
       <MaxQuotaEdit {...maxQuotaEditProps} iconOnlyView={true} subduedView={true} />
     </span>
   ) : (
-    maxQuotaValue > 0 && <span data-testid={"maxQuotaDisplay"}>| Max Quota: {valueWithUnit(maxQuotaValue, unit)}</span>
+    maxQuotaValue >= 0 && <span data-testid={"maxQuotaDisplay"}>| Max Quota: {valueWithUnit(maxQuotaValue, unit)}</span>
   );
 };
 

--- a/src/components/project/ProjectTableDetails.js
+++ b/src/components/project/ProjectTableDetails.js
@@ -137,6 +137,7 @@ const ProjectTableDetails = (props) => {
         </DataGridCell>
         <DataGridCell>
           <ResourceBarBuilder
+            scope={scope}
             resource={resource}
             az={az}
             unit={unit}

--- a/src/components/project/ProjectTableDetails.js
+++ b/src/components/project/ProjectTableDetails.js
@@ -136,7 +136,13 @@ const ProjectTableDetails = (props) => {
           </Stack>
         </DataGridCell>
         <DataGridCell>
-          <ResourceBarBuilder resource={az} unit={unit} barType={"granular"} isEditableResource={isEditableResource} />
+          <ResourceBarBuilder
+            parent={resource}
+            resource={az}
+            unit={unit}
+            barType={"granular"}
+            isEditableResource={isEditableResource}
+          />
         </DataGridCell>
         <DataGridCell>
           <div key={metadata.name}>

--- a/src/components/project/ProjectTableDetails.js
+++ b/src/components/project/ProjectTableDetails.js
@@ -137,8 +137,8 @@ const ProjectTableDetails = (props) => {
         </DataGridCell>
         <DataGridCell>
           <ResourceBarBuilder
-            parent={resource}
-            resource={az}
+            resource={resource}
+            az={az}
             unit={unit}
             barType={"granular"}
             isEditableResource={isEditableResource}

--- a/src/components/resourceBar/ResourceBar.js
+++ b/src/components/resourceBar/ResourceBar.js
@@ -101,7 +101,7 @@ const ResourceBar = (props) => {
 
   const barStyle = {
     width: widthPercent + "%",
-    background: getAppliedBarColors(barValues, styles)
+    background: getAppliedBarColors(barValues, styles),
   };
 
   const barVariant = {
@@ -112,7 +112,11 @@ const ResourceBar = (props) => {
   function buildResourceBar() {
     return (
       <div className={`${baseResourceBar} ${styles.base || baseBarBackground} ${barVariant[variant]}`}>
-        <div key="base-bar" className={`${filledResourceBar} ${barStyle.background} w-[${barStyle.width}%]`} style={barStyle} />
+        <div
+          key="base-bar"
+          className={`${filledResourceBar} ${barStyle.background} w-[${barStyle.width}%]`}
+          style={barStyle}
+        />
       </div>
     );
   }

--- a/src/components/resourceBar/ResourceBar.js
+++ b/src/components/resourceBar/ResourceBar.js
@@ -15,38 +15,38 @@
  */
 
 import React from "react";
-import { Stack } from "@cloudoperators/juno-ui-components";
+import { Stack, Tooltip, TooltipContent, TooltipTrigger } from "@cloudoperators/juno-ui-components";
 
 const baseResourceBar = `
-  rounded-sm 
-  border 
-  border-theme-background-lvl-5 
-  flex 
+rounded-sm 
+border 
+border-theme-background-lvl-5 
+flex 
 `;
 const baseBarBackground = `bg-theme-background-lvl-2`;
 const filledResourceBar = `
-  text-white
-  rounded-sm 
-  `;
-const filledBarBackground = `bg-sap-blue-3`;
+text-white
+rounded-sm 
+`;
 const noneResourceBar = `
-  rounded-sm 
-  border 
-  border-theme-background-lvl-4
-  flex 
-  p-0.5
-  text-theme-light 
-  italic
-  `;
+rounded-sm 
+border 
+border-theme-background-lvl-4
+flex 
+p-0.5
+text-theme-light 
+italic
+`;
 const disabledLabel = `
-    text-theme-light 
-    italic
-    px-1
-    text-sm
-    font-bold
-  `;
+text-theme-light 
+italic
+px-1
+text-sm
+font-bold
+`;
 
-const utilizedExceedsAvailable = "repeating-linear-gradient(55deg,#c9302c ,#c9302c  8px,#d9534f 8px,#d9534f 16px)";
+const filledBarBackground = `bg-sap-blue-3`;
+const utilizedExceedsAvailable = `utilized-exceeds-available`;
 
 export const resourceBar = {
   utilized: 0,
@@ -58,6 +58,16 @@ export const barStyles = {
   filled: null,
 };
 
+export function getAppliedBarColors(barValues, style = barStyles) {
+  if (barValues.utilized > barValues.available) {
+    return utilizedExceedsAvailable;
+  }
+  if (style.filled) {
+    return style.filled;
+  }
+  return filledBarBackground;
+}
+
 const ResourceBar = (props) => {
   const {
     barValues,
@@ -66,6 +76,7 @@ const ResourceBar = (props) => {
     isEmptyBar = false,
     styles = { ...barStyles },
     containerWidth = 100,
+    toolTip = "",
   } = props;
 
   if (isEmptyBar) {
@@ -88,16 +99,9 @@ const ResourceBar = (props) => {
     widthPercent = 0.5;
   }
 
-  let gradientBar;
-  if (barValues.utilized > barValues.available) {
-    gradientBar = {
-      background: utilizedExceedsAvailable,
-    };
-  }
-
-  let barStyle = {
+  const barStyle = {
     width: widthPercent + "%",
-    background: gradientBar?.background,
+    background: getAppliedBarColors(barValues, styles)
   };
 
   const barVariant = {
@@ -105,16 +109,25 @@ const ResourceBar = (props) => {
     large: "h-8 p-0.5",
   };
 
+  function buildResourceBar() {
+    return (
+      <div className={`${baseResourceBar} ${styles.base || baseBarBackground} ${barVariant[variant]}`}>
+        <div key="base-bar" className={`${filledResourceBar} ${barStyle.background} w-[${barStyle.width}%]`} style={barStyle} />
+      </div>
+    );
+  }
+
   return (
     <Stack direction="vertical" distribution="between" style={{ width: containerWidth + "%" }}>
       {barLabel}
-      <div className={`${baseResourceBar} ${styles.base || baseBarBackground} ${barVariant[variant]}`}>
-        <div
-          key="base-bar"
-          className={`${filledResourceBar} ${styles.filled || filledBarBackground}`}
-          style={barStyle}
-        />
-      </div>
+      {toolTip ? (
+        <Tooltip triggerEvent="hover">
+          <TooltipTrigger>{buildResourceBar()}</TooltipTrigger>
+          <TooltipContent>{toolTip}</TooltipContent>
+        </Tooltip>
+      ) : (
+        buildResourceBar()
+      )}
     </Stack>
   );
 };

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -29,7 +29,7 @@ const extraBaseStyle = `bg-theme-background-lvl-4`;
 const extraFillStyle = `bg-sap-purple-2`;
 
 const ResourceBarBuilder = (props) => {
-  const { resource, unit: unitName, barType, isEditableResource, showToolTip = false } = { ...props };
+  const { parent, resource, unit: unitName, barType, isEditableResource, showToolTip = false } = { ...props };
   const unit = new Unit(unitName || "");
   const { leftBar, rightBar } = useResourceBarValues(resource, barType);
   const isGranular = barType === ResourceBarType.granular;
@@ -40,7 +40,7 @@ const ResourceBarBuilder = (props) => {
 
   function getResourceBarLabel(bar) {
     if (isEmptyBar) {
-      return getEmptyBarLabel(resource);
+      return getEmptyBarLabel(parent, resource);
     }
 
     const hideLabelInfo = bar === rightBar && hasLeftBar;

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -95,7 +95,7 @@ const ResourceBarBuilder = (props) => {
         />
       </Stack>
       {displayResourceInfo && !isEmptyBar && (
-        <ResourceInfo parent={parent} resource={resource} leftBar={leftBar} rightBar={rightBar} />
+        <ResourceInfo parent={parent} resource={resource} leftBar={leftBar} rightBar={rightBar} unit={unit} />
       )}
     </>
   );

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -19,7 +19,8 @@ import ResourceBar, { getAppliedBarColors } from "./ResourceBar";
 import { Unit } from "../../lib/unit";
 import useResourceBarValues, { ResourceBarType } from "../../hooks/useResourceBarValues";
 import { Stack } from "@cloudoperators/juno-ui-components/index";
-import { getBarLabel, locateAnyAZ, getEmptyBarLabel, hasAnyBarValues } from "./resourceBarUtils";
+import { getBarLabel, getEmptyBarLabel, hasAnyBarValues } from "./resourceBarUtils";
+import { locateBaseQuotaAZ } from "../../lib/utils";
 import ResourceInfo from "./ResourceInfo";
 
 const barConainer = `
@@ -30,16 +31,16 @@ const extraBaseStyle = `bg-theme-background-lvl-4`;
 const extraFillStyle = `bg-sap-purple-2`;
 
 const ResourceBarBuilder = (props) => {
-  const { resource, az, unit: unitName, barType, isEditableResource } = { ...props };
+  const { scope, resource, az, unit: unitName, barType, isEditableResource } = { ...props };
   const { showToolTip = false, displayResourceInfo = false } = { ...props };
-  const currentResource = az ? az : resource;
   const unit = new Unit(unitName || "");
-  const { leftBar, rightBar } = useResourceBarValues(currentResource, barType);
   const isGranular = barType === ResourceBarType.granular;
+  const currentResource = isGranular ? az : resource;
+  const { leftBar, rightBar } = useResourceBarValues(currentResource, barType);
   const hasLeftBar = hasAnyBarValues(leftBar);
   const hasRightBar = hasAnyBarValues(rightBar);
   const isEmptyBar = !hasLeftBar && !hasRightBar;
-  const isEmptyBarWithBaseQuota = isEmptyBar && locateAnyAZ(resource);
+  const isEmptyBarWithBaseQuota = isEmptyBar && locateBaseQuotaAZ(resource);
 
   const paygStyle = { base: hasLeftBar && extraBaseStyle, filled: isEditableResource && extraFillStyle };
   function getResourceBarLabel(bar) {
@@ -97,7 +98,7 @@ const ResourceBarBuilder = (props) => {
         />
       </Stack>
       {displayResourceInfo && (!isEmptyBar || isEmptyBarWithBaseQuota) && (
-        <ResourceInfo resource={resource} az={az} leftBar={leftBar} rightBar={rightBar} unit={unit} />
+        <ResourceInfo scope={scope} resource={resource} az={az} leftBar={leftBar} rightBar={rightBar} unit={unit} />
       )}
     </>
   );

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -93,7 +93,7 @@ const ResourceBarBuilder = (props) => {
           toolTip={showToolTip && getResourceBarToolTip(rightBar)}
         />
       </Stack>
-      {displayResourceInfo && (
+      {displayResourceInfo && !isEmptyBar && (
         <ResourceInfo parent={parent} resource={resource} leftBar={leftBar} rightBar={rightBar} />
       )}
     </>

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -15,7 +15,7 @@
  */
 
 import React from "react";
-import ResourceBar from "./ResourceBar";
+import ResourceBar, { getAppliedBarColors } from "./ResourceBar";
 import { Unit } from "../../lib/unit";
 import useResourceBarValues, { ResourceBarType } from "../../hooks/useResourceBarValues";
 import { Stack } from "@cloudoperators/juno-ui-components/index";
@@ -25,19 +25,18 @@ const barConainer = `
   min-w-full 
   gap-1
 `;
-const extraBaseStyle = `
-  bg-theme-background-lvl-4 
-  `;
+const extraBaseStyle = `bg-theme-background-lvl-4`;
 const extraFillStyle = `bg-sap-purple-2`;
 
 const ResourceBarBuilder = (props) => {
-  const { resource, unit: unitName, barType, isEditableResource } = { ...props };
+  const { resource, unit: unitName, barType, isEditableResource, showToolTip = false } = { ...props };
   const unit = new Unit(unitName || "");
   const { leftBar, rightBar } = useResourceBarValues(resource, barType);
   const isGranular = barType === ResourceBarType.granular;
   const hasLeftBar = leftBar.utilized > 0 || leftBar.available > 0;
   const hasRightBar = rightBar.utilized > 0 || rightBar.available > 0;
   const isEmptyBar = !hasLeftBar && !hasRightBar;
+  const paygStyle = { base: hasLeftBar && extraBaseStyle, filled: isEditableResource && extraFillStyle };
 
   function getResourceBarLabel(bar) {
     if (isEmptyBar) {
@@ -53,6 +52,23 @@ const ResourceBarBuilder = (props) => {
     );
   }
 
+  function getResourceBarToolTip(bar) {
+    let barBackGround;
+    let toolTipContent;
+    if (bar === rightBar) {
+      barBackGround = getAppliedBarColors(bar, paygStyle);
+      toolTipContent = "Pay as you go";
+    } else {
+      barBackGround = getAppliedBarColors(bar);
+      toolTipContent = "Committed usage";
+    }
+    return (
+      <Stack gap="1">
+        <div className={`size-3 m-auto ${barBackGround}`} /> <>{toolTipContent}</>
+      </Stack>
+    );
+  }
+
   return (
     <Stack distribution="between" className={`${barConainer}`}>
       {hasLeftBar && (
@@ -61,6 +77,7 @@ const ResourceBarBuilder = (props) => {
           barLabel={getResourceBarLabel(leftBar)}
           variant={isGranular ? "small" : "large"}
           containerWidth={70}
+          toolTip={showToolTip && getResourceBarToolTip(leftBar)}
         />
       )}
       <ResourceBar
@@ -68,8 +85,9 @@ const ResourceBarBuilder = (props) => {
         barLabel={getResourceBarLabel(rightBar)}
         variant={isGranular ? "small" : "large"}
         containerWidth={hasLeftBar ? 30 : 100}
-        styles={{ base: hasLeftBar && extraBaseStyle, filled: isEditableResource && extraFillStyle }}
+        styles={paygStyle}
         isEmptyBar={isEmptyBar}
+        toolTip={showToolTip && getResourceBarToolTip(rightBar)}
       />
     </Stack>
   );

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -19,7 +19,7 @@ import ResourceBar, { getAppliedBarColors } from "./ResourceBar";
 import { Unit } from "../../lib/unit";
 import useResourceBarValues, { ResourceBarType } from "../../hooks/useResourceBarValues";
 import { Stack } from "@cloudoperators/juno-ui-components/index";
-import { getBarLabel, getEmptyBarLabel, hasAnyBarValues } from "./resourceBarUtils";
+import { getBarLabel, locateAnyAZ, getEmptyBarLabel, hasAnyBarValues } from "./resourceBarUtils";
 import ResourceInfo from "./ResourceInfo";
 
 const barConainer = `
@@ -30,23 +30,25 @@ const extraBaseStyle = `bg-theme-background-lvl-4`;
 const extraFillStyle = `bg-sap-purple-2`;
 
 const ResourceBarBuilder = (props) => {
-  const { parent, resource, unit: unitName, barType, isEditableResource } = { ...props };
+  const { resource, az, unit: unitName, barType, isEditableResource } = { ...props };
   const { showToolTip = false, displayResourceInfo = false } = { ...props };
+  const currentResource = az ? az : resource;
   const unit = new Unit(unitName || "");
-  const { leftBar, rightBar } = useResourceBarValues(resource, barType);
+  const { leftBar, rightBar } = useResourceBarValues(currentResource, barType);
   const isGranular = barType === ResourceBarType.granular;
   const hasLeftBar = hasAnyBarValues(leftBar);
   const hasRightBar = hasAnyBarValues(rightBar);
   const isEmptyBar = !hasLeftBar && !hasRightBar;
-  const paygStyle = { base: hasLeftBar && extraBaseStyle, filled: isEditableResource && extraFillStyle };
+  const isEmptyBarWithBaseQuota = isEmptyBar && locateAnyAZ(resource);
 
+  const paygStyle = { base: hasLeftBar && extraBaseStyle, filled: isEditableResource && extraFillStyle };
   function getResourceBarLabel(bar) {
     if (isEmptyBar) {
-      return getEmptyBarLabel(parent, resource);
+      return getEmptyBarLabel(resource, isGranular);
     }
 
     const hideLabelInfo = bar === rightBar && hasLeftBar;
-    const barLabel = !hideLabelInfo && getBarLabel(resource);
+    const barLabel = !hideLabelInfo && getBarLabel(currentResource);
     return (
       <span className={`progress-bar-label font-bold ${isGranular && "text-xs"}`}>
         {unit.format(bar.utilized) + "/" + unit.format(bar.available)} {<span className="font-normal">{barLabel}</span>}
@@ -94,8 +96,8 @@ const ResourceBarBuilder = (props) => {
           toolTip={showToolTip && getResourceBarToolTip(rightBar)}
         />
       </Stack>
-      {displayResourceInfo && !isEmptyBar && (
-        <ResourceInfo parent={parent} resource={resource} leftBar={leftBar} rightBar={rightBar} unit={unit} />
+      {displayResourceInfo && (!isEmptyBar || isEmptyBarWithBaseQuota) && (
+        <ResourceInfo resource={resource} az={az} leftBar={leftBar} rightBar={rightBar} unit={unit} />
       )}
     </>
   );

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -65,9 +65,10 @@ const ResourceBarBuilder = (props) => {
       toolTipContent = "Committed usage";
     }
     return (
-      <Stack gap="1">
-        <div className={`size-3 m-auto ${barBackGround}`} /> <>{toolTipContent}</>
-      </Stack>
+      <span className="flex justify-center gap-1">
+        <span className={`size-3 m-auto ${barBackGround} block`} />
+        <>{toolTipContent}</>
+      </span>
     );
   }
 

--- a/src/components/resourceBar/ResourceInfo.js
+++ b/src/components/resourceBar/ResourceInfo.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { IntroBox } from "@cloudoperators/juno-ui-components/index";
+
+const ResourceInfo = (/*props*/) => {
+ // const { parent, resource } = { ...props };
+ // const { rightBar, leftBar } = { ...props };
+
+
+  return <IntroBox className="my-1">plain info</IntroBox>;
+};
+
+export default ResourceInfo;

--- a/src/components/resourceBar/ResourceInfo.js
+++ b/src/components/resourceBar/ResourceInfo.js
@@ -16,12 +16,116 @@
 
 import React from "react";
 import { IntroBox } from "@cloudoperators/juno-ui-components/index";
+import { resourceBar } from "./ResourceBar";
+import { Unit } from "../../lib/unit";
+import { getBaseQuotaObject, hasAnyBarValues } from "./resourceBarUtils";
+import { CustomZones } from "../../lib/constants";
+import { globalStore } from "../StoreProvider";
+import { Scope } from "../../lib/scope";
 
-const ResourceInfo = (/*props*/) => {
-  // const { parent, resource } = { ...props };
-  // const { rightBar, leftBar } = { ...props };
+export function getCommittedUsageInfo(leftBar = resourceBar, unit = new Unit()) {
+  const remaining = leftBar.available - leftBar.utilized;
+  switch (true) {
+    case remaining === 0:
+      return `Committments are fully utilized.`;
+    case remaining > 0:
+      return (
+        <>
+          Unused committments: <strong>{unit.format(remaining)}</strong>
+        </>
+      );
+    default:
+      return `Displayed usage should not exceed commitments. Please report your case.`;
+  }
+}
 
-  return <IntroBox className="my-1">plain info</IntroBox>;
+export function getPaygInfo(rightBar = resourceBar, unit) {
+  switch (true) {
+    case rightBar.utilized >= 0:
+      return (
+        <>
+          Pay as you go usage: <strong>{unit.format(rightBar.utilized)}</strong>
+        </>
+      );
+    default:
+      return `Invalid pay as you go usage detected. Please report your case.`;
+  }
+}
+
+export function getBaseQuotaInfo(resource, unit) {
+  const anyAZ = getBaseQuotaObject(resource);
+  if (!anyAZ) return;
+  return (
+    <>
+      Remaining base quota: <strong>{unit.format(anyAZ.quota)}</strong>. Commitments or usage assign quota to this AZ.
+    </>
+  );
+}
+
+export function getRemainingQuotaIsNegativeInfo(
+  resource,
+  rightBar = resourceBar,
+  unit = new Unit(),
+  scope = new Scope()
+) {
+  const sections = [];
+  const availableIsNegative = rightBar.available < 0;
+  if (!availableIsNegative) return sections;
+
+  if (scope.isCluster()) {
+    sections.push(<>Remaining capacity is: {unit.format(rightBar.available)}. Resource might not report capacity.</>);
+    return sections;
+  }
+
+  const anyAZ = getBaseQuotaObject(resource);
+  if (anyAZ) {
+    sections.push(
+      <>
+        Remaining quota is: <strong>{unit.format(rightBar.available)}</strong>. Base quota is in the process of being
+        applied.
+      </>
+    );
+    sections.push(`Please refresh the page to receive updated quota values.`);
+    return sections;
+  }
+}
+
+const ResourceInfo = (props) => {
+  const { parent, resource, unit } = { ...props };
+  const { leftBar, rightBar } = { ...props };
+  const hasLeftBar = hasAnyBarValues(leftBar);
+  const hasRightBar = hasAnyBarValues(rightBar);
+  const { scope } = globalStore();
+
+  const resourceInfos = React.useMemo(() => {
+    const infos = [];
+
+    if (resource.name === CustomZones.UNKNOWN) {
+      infos.push("This AZ contains assets in error states.");
+    }
+    if (hasLeftBar) {
+      infos.push(getCommittedUsageInfo(leftBar, unit));
+    }
+    if (hasRightBar) {
+      infos.push(getPaygInfo(rightBar, unit));
+    }
+    if (parent) {
+      infos.push(getBaseQuotaInfo(parent, unit));
+    }
+    infos.push(...getRemainingQuotaIsNegativeInfo(parent || resource, rightBar, unit, scope));
+
+    return infos;
+  }, [parent, resource, leftBar, rightBar]);
+
+  console.log(resourceInfos);
+
+  return (
+    <IntroBox className="my-1 text-sm">
+      {resourceInfos.map((info, index) => (
+        <p key={index}>{info}</p>
+      ))}
+    </IntroBox>
+  );
 };
 
 export default ResourceInfo;

--- a/src/components/resourceBar/ResourceInfo.js
+++ b/src/components/resourceBar/ResourceInfo.js
@@ -26,7 +26,7 @@ import {
   PAYGLabels,
   BaseQuotaLabels,
   NegativeRemainingQuotaLabels,
-} from "./ResourceInfoLabels";
+} from "./resourceInfoLabels";
 import { Scope } from "../../lib/scope";
 
 const ResourceInfo = (props) => {

--- a/src/components/resourceBar/ResourceInfo.js
+++ b/src/components/resourceBar/ResourceInfo.js
@@ -69,6 +69,9 @@ const ResourceInfo = (props) => {
   }
 
   function getPaygInfo() {
+    if (rightBar.utilized == 0) {
+      return PAYGLabels.UNAVAILABLE;
+    }
     if (rightBar.utilized > 0) {
       return PAYGLabels.AVAILABLE(unit.format(rightBar.utilized));
     }

--- a/src/components/resourceBar/ResourceInfo.js
+++ b/src/components/resourceBar/ResourceInfo.js
@@ -69,7 +69,7 @@ const ResourceInfo = (props) => {
   }
 
   function getPaygInfo() {
-    if (rightBar.utilized >= 0) {
+    if (rightBar.utilized > 0) {
       return PAYGLabels.AVAILABLE(unit.format(rightBar.utilized));
     }
     if (rightBar.utilized < 0) {

--- a/src/components/resourceBar/ResourceInfo.js
+++ b/src/components/resourceBar/ResourceInfo.js
@@ -1,10 +1,25 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { IntroBox } from "@cloudoperators/juno-ui-components/index";
 
 const ResourceInfo = (/*props*/) => {
- // const { parent, resource } = { ...props };
- // const { rightBar, leftBar } = { ...props };
-
+  // const { parent, resource } = { ...props };
+  // const { rightBar, leftBar } = { ...props };
 
   return <IntroBox className="my-1">plain info</IntroBox>;
 };

--- a/src/components/resourceBar/ResourceInfo.test.js
+++ b/src/components/resourceBar/ResourceInfo.test.js
@@ -86,6 +86,11 @@ describe("Resource info tests", () => {
     rerender(<ResourceInfo {...props} />);
     expect(screen.queryByTestId(/PAYG.AVAILABLE/i)).not.toBeInTheDocument();
     expect(screen.queryByTestId(/PAYG.INVALID/i)).not.toBeInTheDocument();
+
+    // resoruces with payg usage 0 should not display info.
+    props.rightBar = resourceBar;
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.queryByTestId(/PAYG.AVAILABLE/i)).not.toBeInTheDocument();
   });
 
   test("renders base quota info", () => {

--- a/src/components/resourceBar/ResourceInfo.test.js
+++ b/src/components/resourceBar/ResourceInfo.test.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import ResourceInfo from "./ResourceInfo";
 import { screen } from "shadow-dom-testing-library";

--- a/src/components/resourceBar/ResourceInfo.test.js
+++ b/src/components/resourceBar/ResourceInfo.test.js
@@ -88,8 +88,9 @@ describe("Resource info tests", () => {
     expect(screen.queryByTestId(/PAYG.INVALID/i)).not.toBeInTheDocument();
 
     // resoruces with payg usage 0 should not display info.
-    props.rightBar = resourceBar;
+    props.rightBar = { utilized: 0, available: 1 };
     rerender(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/PAYG.UNAVAILABLE/i)).toBeInTheDocument();
     expect(screen.queryByTestId(/PAYG.AVAILABLE/i)).not.toBeInTheDocument();
   });
 

--- a/src/components/resourceBar/ResourceInfo.test.js
+++ b/src/components/resourceBar/ResourceInfo.test.js
@@ -1,0 +1,150 @@
+import React from "react";
+import ResourceInfo from "./ResourceInfo";
+import { screen } from "shadow-dom-testing-library";
+import { render } from "@testing-library/react";
+import { resourceBar } from "./ResourceBar";
+import { Unit } from "../../lib/unit";
+import { CustomZones } from "../../lib/constants";
+import { Scope } from "../../lib/scope";
+
+describe("Resource info tests", () => {
+  test("renders AZ error state info", async () => {
+    const props = {
+      resource: {},
+      az: { name: CustomZones.UNKNOWN },
+      leftBar: {},
+      rightBar: {},
+    };
+    render(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/UnknownAZ/i)).toBeInTheDocument();
+  });
+
+  test("renders committed usage info when leftBar has values", () => {
+    const props = {
+      resource: {},
+      az: { name: "AZ1" },
+      unit: new Unit("MiB"),
+      leftBar: { utilized: 1024, available: 1024 },
+      rightBar: resourceBar,
+    };
+
+    const { rerender } = render(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/CommittedUsage.FULLY_UTILIZED/i)).toBeInTheDocument();
+
+    props.leftBar = { utilized: 1024, available: 4096 };
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/CommittedUsage.UNUSED/i)).toBeInTheDocument();
+    expect(screen.getByText("3 GiB")).toBeInTheDocument();
+
+    props.leftBar = { utilized: 1024, available: 512 };
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/CommittedUsage.INVALID/i)).toBeInTheDocument();
+
+    // resources without committed usage should not display info
+    props.leftBar = resourceBar;
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.queryByTestId(/CommittedUsage.FULLY_UTILIZED/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/CommittedUsage.UNUSED/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/CommittedUsage.INVALID/i)).not.toBeInTheDocument();
+  });
+
+  test("renders PAYG info when rightBar has values", () => {
+    const props = {
+      resource: {},
+      az: { name: "AZ1" },
+      unit: new Unit("MiB"),
+      leftBar: resourceBar,
+      rightBar: { utilized: 1024, available: 1024 },
+    };
+
+    const { rerender } = render(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/PAYG.AVAILABLE/i)).toBeInTheDocument();
+    expect(screen.getByText("1 GiB")).toBeInTheDocument();
+
+    props.rightBar = { utilized: -1024, available: 1024 };
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/PAYG.INVALID/i)).toBeInTheDocument();
+
+    // resources without pay as you go usage should not display info.
+    props.rightBar = resourceBar;
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.queryByTestId(/PAYG.AVAILABLE/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/PAYG.INVALID/i)).not.toBeInTheDocument();
+  });
+
+  test("renders base quota info", () => {
+    const props = {
+      scope: new Scope({ projectID: 1, domainID: 2 }),
+      resource: {
+        per_az: [
+          { name: CustomZones.ANY, quota: 1024 },
+          { name: "AZ1", quota: 1024 },
+        ],
+      },
+      az: null,
+      unit: new Unit("MiB"),
+      leftBar: {},
+      rightBar: {},
+    };
+    const { rerender } = render(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/BaseQuota.AVAILABLE/i)).toBeInTheDocument();
+    expect(screen.getByText("1 GiB")).toBeInTheDocument();
+    // AZ info should not be displayed for resource level info.
+    expect(screen.queryByTestId(/BaseQuota.ADDITION/i)).not.toBeInTheDocument();
+
+    // AZ info should contain the info addition.
+    props.az = { name: "AZ1" };
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/BaseQuota.AVAILABLE/i)).toBeInTheDocument();
+    expect(screen.getByText("1 GiB")).toBeInTheDocument();
+    expect(screen.getByTestId(/BaseQuota.ADDITION/i)).toBeInTheDocument();
+    expect(screen.getByTestId(/BaseQuota.AZ/i)).toBeInTheDocument();
+
+    // unknown AZ info should contain specific info.
+    props.az = { name: CustomZones.UNKNOWN };
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/BaseQuota.ADDITION/i)).toBeInTheDocument();
+    expect(screen.getByTestId(/BaseQuota.UNKNOWN/i)).toBeInTheDocument();
+
+    // Provided AZ's without a base quota AZ should not display info.
+    props.resource = {
+      per_az: [
+        { name: "AZ1", quota: 1024 },
+        { name: "AZ2", quota: 1024 },
+      ],
+    };
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.queryByTestId(/BaseQuota.AVAILABLE/i)).not.toBeInTheDocument();
+
+    // AZ unaware resources should not display info.
+    props.resource = {
+      per_az: [{ name: CustomZones.ANY, quota: 1024 }],
+    };
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.queryByTestId(/BaseQuota.AVAILABLE/i)).not.toBeInTheDocument();
+
+    // Cluster level should not display info.
+    props.scope = new Scope({});
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.queryByTestId(/BaseQuota.AVAILABLE/i)).not.toBeInTheDocument();
+  });
+  test("renders negative remaining quota info and refresh link when not in cluster scope", () => {
+    const props = {
+      scope: new Scope({}),
+      resource: {
+        per_az: [{ name: CustomZones.ANY }, { name: "AZ1" }],
+      },
+      az: { name: "AZ1" },
+      unit: new Unit("MiB"),
+      leftBar: {},
+      rightBar: { available: -1024 },
+    };
+    const { rerender } = render(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/NegativeRemainingQuota.CAPACITY/i)).toBeInTheDocument();
+
+    props.scope = new Scope({ projectID: 1, domainID: 2 });
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.getByTestId(/NegativeRemainingQuota.QUOTA/i)).toBeInTheDocument();
+    expect(screen.getByTestId(/NegativeRemainingQuota.REFRESH/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/resourceBar/ResourceInfo.test.js
+++ b/src/components/resourceBar/ResourceInfo.test.js
@@ -144,7 +144,7 @@ describe("Resource info tests", () => {
     rerender(<ResourceInfo {...props} />);
     expect(screen.queryByTestId(/BaseQuota.AVAILABLE/i)).not.toBeInTheDocument();
   });
-  test("renders negative remaining quota info and refresh link when not in cluster scope", () => {
+  test("renders negative remaining quota info", () => {
     const props = {
       scope: new Scope({}),
       resource: {

--- a/src/components/resourceBar/resourceBarUtils.js
+++ b/src/components/resourceBar/resourceBarUtils.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { CustomZones } from "../../lib/constants";
 
 export function getBarLabel(resource) {

--- a/src/components/resourceBar/resourceBarUtils.js
+++ b/src/components/resourceBar/resourceBarUtils.js
@@ -1,0 +1,34 @@
+import { CustomZones } from "../../lib/constants";
+
+export function getBarLabel(resource) {
+  if (resource.commitmentSum > 0) {
+    return "committed";
+  }
+  if (resource.hasOwnProperty("capacity")) {
+    return "capacity used";
+  } else {
+    return "quota used";
+  }
+}
+
+export function getEmptyBarLabel(parent, resource) {
+  if (parent) {
+    if (getBaseQuotaObject(parent)) {
+      return "No usage (has base quota)";
+    }
+  }
+
+  if (resource.hasOwnProperty("capacity")) {
+    return "No capacity";
+  } else {
+    return "No quota";
+  }
+}
+
+export function getBaseQuotaObject(resource) {
+  return resource.per_az.find((az) => az.name === CustomZones.ANY) || false;
+}
+
+export function hasAnyBarValues(barValues) {
+  return barValues.utilized > 0 || barValues.available > 0;
+}

--- a/src/components/resourceBar/resourceBarUtils.js
+++ b/src/components/resourceBar/resourceBarUtils.js
@@ -42,7 +42,7 @@ export function getEmptyBarLabel(parent, resource) {
 }
 
 export function getBaseQuotaObject(resource) {
-  return resource.per_az.find((az) => az.name === CustomZones.ANY) || false;
+  return resource?.per_az.find((az) => az.name === CustomZones.ANY) || false;
 }
 
 export function hasAnyBarValues(barValues) {

--- a/src/components/resourceBar/resourceBarUtils.js
+++ b/src/components/resourceBar/resourceBarUtils.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { CustomZones } from "../../lib/constants";
+import { locateBaseQuotaAZ } from "../../lib/utils";
 
 export function getBarLabel(resource) {
   if (resource.commitmentSum > 0) {
@@ -28,7 +28,7 @@ export function getBarLabel(resource) {
 }
 
 export function getEmptyBarLabel(resource) {
-  if (locateAnyAZ(resource)) {
+  if (locateBaseQuotaAZ(resource)) {
     return "No usage (has base quota)";
   }
 
@@ -37,10 +37,6 @@ export function getEmptyBarLabel(resource) {
   } else {
     return "No quota";
   }
-}
-
-export function locateAnyAZ(resource) {
-  return resource?.per_az?.find((az) => az.name === CustomZones.ANY) || false;
 }
 
 export function hasAnyBarValues(barValues) {

--- a/src/components/resourceBar/resourceBarUtils.js
+++ b/src/components/resourceBar/resourceBarUtils.js
@@ -27,11 +27,9 @@ export function getBarLabel(resource) {
   }
 }
 
-export function getEmptyBarLabel(parent, resource) {
-  if (parent) {
-    if (getBaseQuotaObject(parent)) {
-      return "No usage (has base quota)";
-    }
+export function getEmptyBarLabel(resource) {
+  if (locateAnyAZ(resource)) {
+    return "No usage (has base quota)";
   }
 
   if (resource.hasOwnProperty("capacity")) {
@@ -41,8 +39,8 @@ export function getEmptyBarLabel(parent, resource) {
   }
 }
 
-export function getBaseQuotaObject(resource) {
-  return resource?.per_az.find((az) => az.name === CustomZones.ANY) || false;
+export function locateAnyAZ(resource) {
+  return resource?.per_az?.find((az) => az.name === CustomZones.ANY) || false;
 }
 
 export function hasAnyBarValues(barValues) {

--- a/src/components/resourceBar/resourceBarUtils.js
+++ b/src/components/resourceBar/resourceBarUtils.js
@@ -28,13 +28,12 @@ export function getBarLabel(resource) {
 }
 
 export function getEmptyBarLabel(resource) {
-  if (locateBaseQuotaAZ(resource)) {
-    return "No usage (has base quota)";
-  }
-
   if (resource.hasOwnProperty("capacity")) {
     return "No capacity";
   } else {
+    if (locateBaseQuotaAZ(resource)) {
+      return "No usage (has base quota)";
+    }
     return "No quota";
   }
 }

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -17,7 +17,11 @@
 import React from "react";
 import { CustomZones } from "../../lib/constants";
 
-export const UnknownAZLabel = <span data-testid="UnknownAZ">This usage number accounts for assets in error states that are not associated with a real AZ.</span>;
+export const UnknownAZLabel = (
+  <span data-testid="UnknownAZ">
+    This usage number accounts for assets in error states that are not associated with a real AZ.
+  </span>
+);
 
 export const CommittedUsageLabels = {
   FULLY_UTILIZED: <span data-testid="CommittedUsage.FULLY_UTILIZED">Commitments are fully utilized.</span>,
@@ -40,7 +44,9 @@ export const PAYGLabels = {
     </span>
   ),
   UNAVAILABLE: <span data-testid="PAYG.UNAVAILABLE">No Pay-As-You-Go usage present.</span>,
-  INVALID: <span data-testid="PAYG.INVALID">Invalid Pay-As-You-Go usage detected. Please create a support ticket.</span>,
+  INVALID: (
+    <span data-testid="PAYG.INVALID">Invalid Pay-As-You-Go usage detected. Please create a support ticket.</span>
+  ),
 };
 
 export const BaseQuotaLabels = {
@@ -75,6 +81,8 @@ export const NegativeRemainingQuotaLabels = {
     </span>
   ),
   REFRESH: (
-    <span data-testid="NegativeRemainingQuota.REFRESH">Please refresh the page after a while to receive updated quota values.</span>
+    <span data-testid="NegativeRemainingQuota.REFRESH">
+      Please refresh the page after a while to receive updated quota values.
+    </span>
   ),
 };

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -27,7 +27,7 @@ export const CommittedUsageLabels = {
   FULLY_UTILIZED: <span data-testid="CommittedUsage.FULLY_UTILIZED">Commitments are fully utilized.</span>,
   UNUSED: (amount) => (
     <span data-testid="CommittedUsage.UNUSED">
-      Unused commitments: <strong>{amount}</strong>{" "}
+      Unused commitments: <strong>{amount}</strong>.{" "}
     </span>
   ),
   INVALID: (
@@ -40,7 +40,7 @@ export const CommittedUsageLabels = {
 export const PAYGLabels = {
   AVAILABLE: (amount) => (
     <span data-testid="PAYG.AVAILABLE">
-      Pay-As-You-Go usage: <strong>{amount}</strong>
+      Pay-As-You-Go usage: <strong>{amount}</strong>.
     </span>
   ),
   UNAVAILABLE: <span data-testid="PAYG.UNAVAILABLE">No Pay-As-You-Go usage present.</span>,

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -62,7 +62,7 @@ export const BaseQuotaLabels = {
           ) : (
             <span data-testid="BaseQuota.AZ">Commitments and usage assign</span>
           )}{" "}
-          quota to this AZ.
+          base quota to this AZ.
         </span>
       )}
     </>

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -32,7 +32,7 @@ export const CommittedUsageLabels = {
   ),
   INVALID: (
     <span data-testid="CommittedUsage.INVALID">
-      Displayed usage should not exceed commitments. Please create a support ticket.
+      Displayed commitment usage should not exceed commitment amount. Please create a support ticket.
     </span>
   ),
 };

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -17,7 +17,7 @@
 import React from "react";
 import { CustomZones } from "../../lib/constants";
 
-export const UnknownAZLabel = <span data-testid="UnknownAZ">This AZ contains assets in error states.</span>;
+export const UnknownAZLabel = <span data-testid="UnknownAZ">This usage number accounts for assets in error states that are not associated with a real AZ.</span>;
 
 export const CommittedUsageLabels = {
   FULLY_UTILIZED: <span data-testid="CommittedUsage.FULLY_UTILIZED">Commitments are fully utilized.</span>,

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -39,6 +39,7 @@ export const PAYGLabels = {
       Pay as you go usage: <strong>{amount}</strong>
     </span>
   ),
+  UNAVAILABLE: <span data-testid="PAYG.UNAVAILABLE">No pay as you go usage present.</span>,
   INVALID: <span data-testid="PAYG.INVALID">Invalid pay as you go usage detected. Please report your case.</span>,
 };
 

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -1,0 +1,63 @@
+import React from "react";
+import { CustomZones } from "../../lib/constants";
+
+export const UnknownAZLabel = <span data-testid="UnknownAZ">This AZ contains assets in error states.</span>;
+
+export const CommittedUsageLabels = {
+  FULLY_UTILIZED: <span data-testid="CommittedUsage.FULLY_UTILIZED">Commitments are fully utilized.</span>,
+  UNUSED: (amount) => (
+    <span data-testid="CommittedUsage.UNUSED">
+      Unused commitments: <strong>{amount}</strong>{" "}
+    </span>
+  ),
+  INVALID: (
+    <span data-testid="CommittedUsage.INVALID">
+      Displayed usage should not exceed commitments. Please report your case.
+    </span>
+  ),
+};
+
+export const PAYGLabels = {
+  AVAILABLE: (amount) => (
+    <span data-testid="PAYG.AVAILABLE">
+      Pay as you go usage: <strong>{amount}</strong>
+    </span>
+  ),
+  INVALID: <span data-testid="PAYG.INVALID">Invalid pay as you go usage detected. Please report your case.</span>,
+};
+
+export const BaseQuotaLabels = {
+  AVAILABLE: (amount, az) => (
+    <>
+      <span data-testid="BaseQuota.AVAILABLE">
+        Available base quota: <strong>{amount}</strong>.{" "}
+      </span>{" "}
+      {az && (
+        <span data-testid="BaseQuota.ADDITION">
+          {az.name === CustomZones.UNKNOWN ? (
+            <span data-testid="BaseQuota.UNKNOWN">Usage assigns</span>
+          ) : (
+            <span data-testid="BaseQuota.AZ">Commitments and usage assign</span>
+          )}{" "}
+          quota to this AZ.
+        </span>
+      )}
+    </>
+  ),
+};
+
+export const NegativeRemainingQuotaLabels = {
+  CAPACITY: (amount) => (
+    <span data-testid="NegativeRemainingQuota.CAPACITY">
+      Remaining capacity is: <strong>{amount}</strong>. Resource might not report capacity.
+    </span>
+  ),
+  QUOTA: (amount) => (
+    <span data-testid="NegativeRemainingQuota.QUOTA">
+      Assigned quota is: <strong>{amount}</strong>. Base quota application is processing.
+    </span>
+  ),
+  REFRESH: (
+    <span data-testid="NegativeRemainingQuota.REFRESH">Please refresh the page to receive updated quota values.</span>
+  ),
+};

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { CustomZones } from "../../lib/constants";
 

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -75,6 +75,6 @@ export const NegativeRemainingQuotaLabels = {
     </span>
   ),
   REFRESH: (
-    <span data-testid="NegativeRemainingQuota.REFRESH">Please refresh the page to receive updated quota values.</span>
+    <span data-testid="NegativeRemainingQuota.REFRESH">Please refresh the page after a while to receive updated quota values.</span>
   ),
 };

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -28,7 +28,7 @@ export const CommittedUsageLabels = {
   ),
   INVALID: (
     <span data-testid="CommittedUsage.INVALID">
-      Displayed usage should not exceed commitments. Please report your case.
+      Displayed usage should not exceed commitments. Please create a support ticket.
     </span>
   ),
 };
@@ -36,11 +36,11 @@ export const CommittedUsageLabels = {
 export const PAYGLabels = {
   AVAILABLE: (amount) => (
     <span data-testid="PAYG.AVAILABLE">
-      Pay as you go usage: <strong>{amount}</strong>
+      Pay-As-You-Go usage: <strong>{amount}</strong>
     </span>
   ),
-  UNAVAILABLE: <span data-testid="PAYG.UNAVAILABLE">No pay as you go usage present.</span>,
-  INVALID: <span data-testid="PAYG.INVALID">Invalid pay as you go usage detected. Please report your case.</span>,
+  UNAVAILABLE: <span data-testid="PAYG.UNAVAILABLE">No Pay-As-You-Go usage present.</span>,
+  INVALID: <span data-testid="PAYG.INVALID">Invalid Pay-As-You-Go usage detected. Please create a support ticket.</span>,
 };
 
 export const BaseQuotaLabels = {

--- a/src/lib/resourceBarValues.js
+++ b/src/lib/resourceBarValues.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { CustomZones } from "./constants";
 import { tracksQuota } from "./utils";
 
 // AZs may or may not contain their own values.
@@ -118,7 +119,14 @@ export function getBarLabel(resource) {
   }
 }
 
-export function getEmptyBarLabel(resource) {
+export function getEmptyBarLabel(parent, resource) {
+  if (parent) {
+    const hasBaseQuota = parent.per_az.some((az) => az.name === CustomZones.ANY);
+    if (hasBaseQuota) {
+      return "No usage (has base quota)";
+    }
+  }
+
   if (resource.hasOwnProperty("capacity")) {
     return "No capacity";
   } else {

--- a/src/lib/resourceBarValues.js
+++ b/src/lib/resourceBarValues.js
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { CustomZones } from "./constants";
 import { tracksQuota } from "./utils";
 
 // AZs may or may not contain their own values.
@@ -105,31 +104,5 @@ export function getRemainingCapacity(resource) {
     return resource.quota - commitments;
   } else {
     return resource.usage - commitments;
-  }
-}
-
-export function getBarLabel(resource) {
-  if (resource.commitmentSum > 0) {
-    return "committed";
-  }
-  if (resource.hasOwnProperty("capacity")) {
-    return "capacity used";
-  } else {
-    return "quota used";
-  }
-}
-
-export function getEmptyBarLabel(parent, resource) {
-  if (parent) {
-    const hasBaseQuota = parent.per_az.some((az) => az.name === CustomZones.ANY);
-    if (hasBaseQuota) {
-      return "No usage (has base quota)";
-    }
-  }
-
-  if (resource.hasOwnProperty("capacity")) {
-    return "No capacity";
-  } else {
-    return "No quota";
   }
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -139,3 +139,8 @@ export function isAZUnaware(az) {
   if (az?.length == 1 && az[0].name == CustomZones.ANY) return true;
   return false;
 }
+
+export function locateBaseQuotaAZ(resource) {
+  if (isAZUnaware(resource?.per_az)) return null;
+  return resource?.per_az?.find((az) => az.name === CustomZones.ANY) || null;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,6 +21,10 @@
 
 /* If necessary, app styles can be added below */
 
+.utilized-exceeds-available {
+  background: repeating-linear-gradient(55deg,#c9302c ,#c9302c  8px,#d9534f 8px,#d9534f 16px);
+}
+
 // .btn {
 //   @apply font-bold bg-theme-background-lvl-4 text-theme-default py-2 px-3 flex-initial justify-center rounded;
 // }


### PR DESCRIPTION
This PR contains the following enhancements to improve the UX:

- [x] Add a explanatory toolTip whether a sumBar contains committed usage or pay as you go content combined with a color coding info.
- [x] Change "No quota" display for resources which contain base Quota to "No usage"
- [x] Add InfoBoxes for the resource bars which explain the current state and meaning of the bar values.
- [x] Add unit tests

The info boxes contain info about the state of the resources or AZ's.

Example 1: 

<img width="554" alt="image" src="https://github.com/user-attachments/assets/72d37926-cb33-4799-a6ef-89b6aa98460d" />

sumbar. Contains info about the bar states, base quota and info about the case if a requery occurs before limes can assign the available base quota and add it autogrow.

Example 2:

<img width="557" alt="image" src="https://github.com/user-attachments/assets/6e7d28df-f62a-4ec9-9dbe-a891bb41daaf" />

unknown AZ contains special info about what its for. For base quota other AZ's contain the addition that it can be assigned by commitments as well.

Example 3:

<img width="550" alt="image" src="https://github.com/user-attachments/assets/ff59972d-b5cc-4d5a-b1db-e8d30e77e62d" />

if base quota is present, but nothing is assigned yet, it will be displayed labeled as such.
