### PR TITLE
fix: renovate groups

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,8 +30,7 @@
         "before 8am on Friday"
       ],
       "matchPackageNames": [
-        "/^react$/",
-        "/^react-.*/"
+        "/^react.*/"
       ]
     },
     {
@@ -48,8 +47,7 @@
       "groupName": "tailwind packages",
       "description": "Updates for Tailwind and related packages separately",
       "matchPackageNames": [
-        "/^tailwindcss/",
-        "/^tailwindcss-.*/"
+        "/^tailwindcss.*/"
       ],
       "schedule": [
         "before 8am on Friday"
@@ -62,6 +60,9 @@
         "before 8am on Friday"
       ],
       "matchPackageNames": [
+        "!/^react.*/",
+        "!/^@cloudoperators/.*/",
+        "!/^tailwindcss.*/",
         "/.*/"
       ]
     }


### PR DESCRIPTION
Now I tested the output locally with: `renovate --platform=local `
by providing the env `LOG_LEVEL=debug` and ` RENOVATE_CONFIG_FILE=.github/renovate.json`

The catch is that renovate merges the packageRule results if multiple hit where the last match can overwrite configurations from a previous rule. 
So we could theoretically have the misc rule on top and the other below it, the result would be the same, however, having the negations on it and have this rule as the last rule prevents us from having undesired side effects with overriden configs in the future.