### PR TITLE
ignore majorMinor separation for misc

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,6 +59,7 @@
       "schedule": [
         "before 8am on Friday"
       ],
+      "separateMajorMinor": false,
       "matchPackageNames": [
         "!/^react.*/",
         "!/^@cloudoperators/.*/",


### PR DESCRIPTION
One last improvent suggestion. For react, cloudoperators and tailwind, I'm OK with having major releases devided from minor/patch releases.
However for everything else, I don't expect major breakage for the application, so I would disable this distinction for the misc group.