### PR TITLE
Fix: usage explanation for basic resources

### DIFF
--- a/.changeset/evil-ideas-mix.md
+++ b/.changeset/evil-ideas-mix.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": minor
+---
+
+Add commitment marketplace.

--- a/src/components/commitment/CommitmentTable.js
+++ b/src/components/commitment/CommitmentTable.js
@@ -31,7 +31,7 @@ const CommitmentTable = (props) => {
   const { commitmentIsFetching } = createCommitmentStore();
   const commitmentTransferID = React.useRef(null);
   const { isCommitting } = createCommitmentStore();
-  const { serviceType, currentCategory, currentResource, currentAZ, commitmentData, mergeOps } = {
+  const { serviceType, currentCategory, currentResource, currentTab, commitmentData, mergeOps } = {
     ...props,
   };
   const durations = getResourceDurations(currentResource);
@@ -90,9 +90,9 @@ const CommitmentTable = (props) => {
 
   //Add or remove edit commitment row.
   const filteredCommitments = React.useMemo(() => {
-    const filteredData = filterCommitments(resourceName, currentAZ);
+    const filteredData = filterCommitments(resourceName, currentTab);
     return filteredData;
-  }, [commitmentData, currentAZ, resourceName]);
+  }, [commitmentData, currentTab, resourceName]);
 
   const { items, TableSortHeader } = useSortTableData(filteredCommitments, initialSortConfig);
 
@@ -134,7 +134,7 @@ const CommitmentTable = (props) => {
           serviceType={serviceType}
           currentCategory={currentCategory}
           currentResource={currentResource}
-          currentAZ={currentAZ}
+          currentTab={currentTab}
           commitmentTransferID={commitmentTransferID}
           mergeOps={mergeOps}
         />

--- a/src/components/commitment/CommitmentTableDetails.js
+++ b/src/components/commitment/CommitmentTableDetails.js
@@ -32,7 +32,7 @@ const transferLabel = Object.freeze({
 });
 
 const CommitmentTableDetails = (props) => {
-  const { commitment, commitmentTransferID, mergeOps } = props;
+  const { currentTab, commitment, commitmentTransferID, mergeOps } = props;
   const {
     id,
     amount,
@@ -49,7 +49,6 @@ const CommitmentTableDetails = (props) => {
   const serviceType = props.serviceType;
   const currentResource = props.currentResource;
   const resourceName = currentResource?.name;
-  const currentAZ = props.currentAZ;
   const isAddingCommitment = id === COMMITMENTID ? true : false;
   const { commitment: newCommitment } = createCommitmentStore();
   const { commitmentIsLoading } = createCommitmentStore();
@@ -110,7 +109,7 @@ const CommitmentTableDetails = (props) => {
       ...newCommitment,
       service_type: serviceType,
       resource_name: resourceName,
-      availability_zone: currentAZ,
+      availability_zone: currentTab,
       amount: parsedInput,
       durationLabel: durationLabel.current,
     });

--- a/src/components/commitment/CommitmentTableDetails.js
+++ b/src/components/commitment/CommitmentTableDetails.js
@@ -234,7 +234,9 @@ const CommitmentTableDetails = (props) => {
               }}
               disabled={newCommitment?.id == id}
             >
-              {commitment.id == commitmentTransferID.current ? transferLabel.Selected : transferLabel.Move}
+              {isTransferring && commitment.id == commitmentTransferID.current
+                ? transferLabel.Selected
+                : transferLabel.Move}
             </Button>
             <Button
               size="small"

--- a/src/components/commitment/Marketplace.js
+++ b/src/components/commitment/Marketplace.js
@@ -1,0 +1,7 @@
+import React from "react";
+
+const Marketplace = () => {
+  return <div>Marketplace</div>;
+};
+
+export default Marketplace;

--- a/src/components/commitment/Marketplace.js
+++ b/src/components/commitment/Marketplace.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { DataGrid, DataGridRow, IntroBox, LoadingIndicator, Message } from "@cloudoperators/juno-ui-components/index";
 import useSortTableData from "../../hooks/useSortTable";

--- a/src/components/commitment/Marketplace.js
+++ b/src/components/commitment/Marketplace.js
@@ -78,8 +78,8 @@ const Marketplace = (props) => {
           <MarketplaceDetails
             key={commitment.id}
             project={project}
-            commitment={commitment}
             resource={resource}
+            commitment={commitment}
             transferCommitment={transferCommitment}
           />
         ))}

--- a/src/components/commitment/Marketplace.js
+++ b/src/components/commitment/Marketplace.js
@@ -4,7 +4,7 @@ import useSortTableData from "../../hooks/useSortTable";
 import MarketplaceDetails from "./MarketplaceDetails";
 
 const Marketplace = (props) => {
-  const { resource, publicCommitmentQuery } = props;
+  const { project, resource, publicCommitmentQuery, transferCommitment } = props;
   const { data, isLoading, isError, error } = publicCommitmentQuery;
   const publicCommitments = data?.commitments || [];
 
@@ -59,7 +59,13 @@ const Marketplace = (props) => {
           ))}
         </DataGridRow>
         {items.map((commitment) => (
-          <MarketplaceDetails key={commitment.id} commitment={commitment} resource={resource} />
+          <MarketplaceDetails
+            key={commitment.id}
+            project={project}
+            commitment={commitment}
+            resource={resource}
+            transferCommitment={transferCommitment}
+          />
         ))}
       </DataGrid>
     )

--- a/src/components/commitment/Marketplace.js
+++ b/src/components/commitment/Marketplace.js
@@ -1,7 +1,13 @@
 import React from "react";
+import { useQuery } from "@tanstack/react-query";
 
-const Marketplace = () => {
-  return <div>Marketplace</div>;
+const Marketplace = (props) => {
+  const { serviceType, resource } = props;
+  const publicCommitmentQuery = useQuery({
+    queryKey: ["publicCommitments", { service: serviceType, resource: resource.name }],
+  });
+  const { data, isLoading, isError } = publicCommitmentQuery;
+  return <div>{JSON.stringify(data)}</div>;
 };
 
 export default Marketplace;

--- a/src/components/commitment/Marketplace.js
+++ b/src/components/commitment/Marketplace.js
@@ -1,13 +1,69 @@
 import React from "react";
-import { useQuery } from "@tanstack/react-query";
+import { DataGrid, DataGridRow, IntroBox, LoadingIndicator, Message } from "@cloudoperators/juno-ui-components/index";
+import useSortTableData from "../../hooks/useSortTable";
+import MarketplaceDetails from "./MarketplaceDetails";
 
 const Marketplace = (props) => {
-  const { serviceType, resource } = props;
-  const publicCommitmentQuery = useQuery({
-    queryKey: ["publicCommitments", { service: serviceType, resource: resource.name }],
-  });
-  const { data, isLoading, isError } = publicCommitmentQuery;
-  return <div>{JSON.stringify(data)}</div>;
+  const { resource, publicCommitmentQuery } = props;
+  const { data, isLoading, isError, error } = publicCommitmentQuery;
+  const publicCommitments = data?.commitments || [];
+
+  const initialSortConfig = {
+    expires_at: {
+      direction: "ascending",
+      sortStrategy: "numeric",
+    },
+  };
+  const { items, TableSortHeader } = useSortTableData(publicCommitments, initialSortConfig);
+
+  const headCells = [
+    {
+      key: "amount",
+      label: "Amount",
+      sortStrategy: "numeric",
+    },
+    {
+      key: "availability_zone",
+      label: "Zone",
+      sortStrategy: "text",
+    },
+    {
+      key: "duration",
+      label: "Duration",
+      sortStrategy: "text",
+    },
+    {
+      key: "expires_at",
+      label: "Expires",
+      sortStrategy: "numeric",
+    },
+    {
+      key: "edit",
+      label: "Actions",
+    },
+  ];
+
+  return (
+    (isLoading && <LoadingIndicator className="m-auto" />) ||
+    (isError && <Message variant="danger" text={error.toString()} />) ||
+    (publicCommitments.length == 0 && <IntroBox text="No commitments available." />) || (
+      <DataGrid columns={headCells.length}>
+        <DataGridRow>
+          {headCells.map((headCell) => (
+            <TableSortHeader
+              key={headCell.key}
+              identifier={headCell.key}
+              value={headCell.label}
+              sortStrategy={headCell.sortStrategy}
+            />
+          ))}
+        </DataGridRow>
+        {items.map((commitment) => (
+          <MarketplaceDetails key={commitment.id} commitment={commitment} resource={resource} />
+        ))}
+      </DataGrid>
+    )
+  );
 };
 
 export default Marketplace;

--- a/src/components/commitment/MarketplaceDetails.js
+++ b/src/components/commitment/MarketplaceDetails.js
@@ -13,8 +13,6 @@ const MarketplaceDetails = (props) => {
   const { getCommitmentLabel } = useCommitmentFilter();
   const [showModal, setShowModal] = React.useState(false);
 
-  console.log(commitment)
-
   return (
     <DataGridRow>
       <DataGridCell>{valueWithUnit(commitment.amount, unit)}</DataGridCell>

--- a/src/components/commitment/MarketplaceDetails.js
+++ b/src/components/commitment/MarketplaceDetails.js
@@ -25,7 +25,6 @@ import MarketplaceModal from "./Modals/MarketplaceModal";
 const MarketplaceDetails = (props) => {
   const { project, resource, commitment, transferCommitment } = props;
   const unit = new Unit(resource.unit);
-  const transferToken = commitment.transfer_token;
   const { getCommitmentLabel } = useCommitmentFilter();
   const [showModal, setShowModal] = React.useState(false);
 
@@ -48,14 +47,13 @@ const MarketplaceDetails = (props) => {
       </DataGridCell>
       {showModal && (
         <MarketplaceModal
-          action={() => {
-            transferCommitment(project, commitment, transferToken);
-          }}
+          action={transferCommitment}
           title="Marketplace: Receive commitment"
           subText="receive"
           onModalClose={() => {
             setShowModal(false);
           }}
+          project={project}
           commitment={commitment}
         />
       )}

--- a/src/components/commitment/MarketplaceDetails.js
+++ b/src/components/commitment/MarketplaceDetails.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { DataGridRow, DataGridCell, Stack, Button } from "@cloudoperators/juno-ui-components/index";
 import { valueWithUnit, Unit } from "../../lib/unit";

--- a/src/components/commitment/MarketplaceDetails.js
+++ b/src/components/commitment/MarketplaceDetails.js
@@ -1,20 +1,50 @@
 import React from "react";
-import { DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components/index";
+import { DataGridRow, DataGridCell, Stack, Button } from "@cloudoperators/juno-ui-components/index";
 import { valueWithUnit, Unit } from "../../lib/unit";
-import { formatTimeISO8160 } from "../../lib/utils";
+import { formatTimeISO8160, formatTime } from "../../lib/utils";
 import useCommitmentFilter from "../../hooks/useCommitmentFilter";
+import ToolTipWrapper from "../shared/ToolTipWrapper";
+import MarketplaceModal from "./Modals/MarketplaceModal";
 
 const MarketplaceDetails = (props) => {
-  const { commitment, resource } = props;
+  const { project, resource, commitment, transferCommitment } = props;
   const unit = new Unit(resource.unit);
+  const transferToken = commitment.transfer_token;
   const { getCommitmentLabel } = useCommitmentFilter();
+  const [showModal, setShowModal] = React.useState(false);
+
+  console.log(commitment)
+
   return (
     <DataGridRow>
       <DataGridCell>{valueWithUnit(commitment.amount, unit)}</DataGridCell>
       <DataGridCell>{commitment.availability_zone}</DataGridCell>
       <DataGridCell>{commitment.duration}</DataGridCell>
-      <DataGridCell>{formatTimeISO8160(commitment.expires_at)}</DataGridCell>
-      <DataGridCell>{getCommitmentLabel(commitment)}</DataGridCell>
+      <DataGridCell className="items-start">
+        <ToolTipWrapper
+          trigger={formatTimeISO8160(commitment.expires_at)}
+          content={formatTime(commitment.expires_at, "YYYY-MM-DD HH:mm A")}
+        />
+      </DataGridCell>
+      <DataGridCell>
+        <Stack gap="1" distribution="between">
+          {getCommitmentLabel(commitment)}{" "}
+          <Button variant="primary" icon="download" size="small" onClick={() => setShowModal(true)} />
+        </Stack>
+      </DataGridCell>
+      {showModal && (
+        <MarketplaceModal
+          action={() => {
+            transferCommitment(project, commitment, transferToken);
+          }}
+          title="Marketplace: Receive commitment"
+          subText="receive"
+          onModalClose={() => {
+            setShowModal(false);
+          }}
+          commitment={commitment}
+        />
+      )}
     </DataGridRow>
   );
 };

--- a/src/components/commitment/MarketplaceDetails.js
+++ b/src/components/commitment/MarketplaceDetails.js
@@ -1,0 +1,22 @@
+import React from "react";
+import { DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components/index";
+import { valueWithUnit, Unit } from "../../lib/unit";
+import { formatTimeISO8160 } from "../../lib/utils";
+import useCommitmentFilter from "../../hooks/useCommitmentFilter";
+
+const MarketplaceDetails = (props) => {
+  const { commitment, resource } = props;
+  const unit = new Unit(resource.unit);
+  const { getCommitmentLabel } = useCommitmentFilter();
+  return (
+    <DataGridRow>
+      <DataGridCell>{valueWithUnit(commitment.amount, unit)}</DataGridCell>
+      <DataGridCell>{commitment.availability_zone}</DataGridCell>
+      <DataGridCell>{commitment.duration}</DataGridCell>
+      <DataGridCell>{formatTimeISO8160(commitment.expires_at)}</DataGridCell>
+      <DataGridCell>{getCommitmentLabel(commitment)}</DataGridCell>
+    </DataGridRow>
+  );
+};
+
+export default MarketplaceDetails;

--- a/src/components/commitment/Modals/CommitmentModal.js
+++ b/src/components/commitment/Modals/CommitmentModal.js
@@ -34,7 +34,7 @@ import { formatTimeISO8160 } from "../../../lib/utils";
 const label = "font-semibold";
 
 const CommitmentModal = (props) => {
-  const { action, az, canConfirm, commitment, minConfirmDate, onModalClose, subText, title } = { ...props };
+  const { action, currentTab, canConfirm, commitment, minConfirmDate, onModalClose, subText, title } = { ...props };
   const unit = new Unit(commitment.unit);
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({ confirmationText: subText });
   const hasMinConfirmDate = minConfirmDate ? true : false;
@@ -99,7 +99,7 @@ const CommitmentModal = (props) => {
       <DataGrid columns={2} className={!showCalendar ? "mb-6" : "mb-0"} columnMaxSize="1fr">
         <DataGridRow>
           <DataGridCell className={label}>Availability Zone:</DataGridCell>
-          <DataGridCell>{az}</DataGridCell>
+          <DataGridCell>{currentTab}</DataGridCell>
         </DataGridRow>
         <DataGridRow>
           <DataGridCell className={label}>Amount:</DataGridCell>

--- a/src/components/commitment/Modals/CommitmentModal.test.js
+++ b/src/components/commitment/Modals/CommitmentModal.test.js
@@ -37,7 +37,7 @@ describe("test commitment creation modal", () => {
         <CommitmentModal
           title="Confirm commitment creation"
           subText="Commit"
-          az={"az1"}
+          currentTab={"az1"}
           canConfirm={false}
           minConfirmDate={null}
           commitment={newCommitment}
@@ -70,7 +70,7 @@ describe("test commitment creation modal", () => {
         <CommitmentModal
           title="Confirm commitment creation"
           subText="Commit"
-          az={"az1"}
+          currentTab={"az1"}
           canConfirm={true}
           minConfirmDate={moment(new Date("2024-01-01T00:00:00.000Z")).utc().unix()}
           commitment={newCommitment}
@@ -102,7 +102,7 @@ describe("test commitment creation modal", () => {
         <CommitmentModal
           title="Confirm commitment creation"
           subText="Commit"
-          az={"az1"}
+          currentTab={"az1"}
           canConfirm={true}
           minConfirmDate={moment(new Date("2024-01-02T00:00:00.000Z")).utc().unix()}
           commitment={newCommitment}
@@ -143,7 +143,7 @@ describe("test commitment creation modal", () => {
         <CommitmentModal
           title="Confirm commitment creation"
           subText="Commit"
-          az={"az1"}
+          currentTab={"az1"}
           canConfirm={true}
           commitment={newCommitment}
           action={onConfirm}

--- a/src/components/commitment/Modals/DeleteModal.js
+++ b/src/components/commitment/Modals/DeleteModal.js
@@ -24,7 +24,7 @@ import { Unit } from "../../../lib/unit";
 const label = "font-semibold";
 
 const DeleteModal = (props) => {
-  const { action, az, title, subText, onModalClose, commitment } = props;
+  const { action, currentTab, title, subText, onModalClose, commitment } = props;
   const unit = new Unit(commitment.unit);
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
     confirmationText: subText,
@@ -54,7 +54,7 @@ const DeleteModal = (props) => {
       <DataGrid columns={2} columnMaxSize="1fr">
         <DataGridRow>
           <DataGridCell className={label}>Availability Zone:</DataGridCell>
-          <DataGridCell>{az}</DataGridCell>
+          <DataGridCell>{currentTab}</DataGridCell>
         </DataGridRow>
         <DataGridRow>
           <DataGridCell className={label}>Amount:</DataGridCell>

--- a/src/components/commitment/Modals/MarketplaceModal.js
+++ b/src/components/commitment/Modals/MarketplaceModal.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { Modal, DataGrid, DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components";
 import BaseFooter from "./BaseComponents/BaseFooter";

--- a/src/components/commitment/Modals/MarketplaceModal.js
+++ b/src/components/commitment/Modals/MarketplaceModal.js
@@ -108,13 +108,14 @@ const MarketplaceModal = (props) => {
             <DataGridCell className={label}>Target project:</DataGridCell>
             <DataGridCell>
               <Select
+                data-testid={"targetProjectSelect"}
                 disabled={sortedProjects.length == 0}
                 onChange={(project) => {
                   setTargetProject(project);
                 }}
               >
                 {sortedProjects.map((project) => (
-                  <SelectOption key={project["metadata"]["id"]} value={project}>
+                  <SelectOption data-testid={`selectOption`} key={project["metadata"]["id"]} value={project}>
                     {scope.isDomain() && project["metadata"]["name"]}
                     {scope.isCluster() && project["metadata"]["fullName"]}
                   </SelectOption>

--- a/src/components/commitment/Modals/MarketplaceModal.js
+++ b/src/components/commitment/Modals/MarketplaceModal.js
@@ -1,0 +1,58 @@
+import React from "react";
+import { Modal, DataGrid, DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components";
+import BaseFooter from "./BaseComponents/BaseFooter";
+import useConfirmInput from "./BaseComponents/useConfirmInput";
+import { formatTimeISO8160 } from "../../../lib/utils";
+import { valueWithUnit } from "../../../lib/unit";
+import { Unit } from "../../../lib/unit";
+
+const label = "font-semibold";
+
+const MarketplaceModal = (props) => {
+  const { action, title, subText, onModalClose, commitment } = props;
+  const { amount, availability_zone, duration, expires_at } = commitment;
+  const unit = new Unit(commitment.unit);
+  const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
+    confirmationText: subText,
+  });
+
+  function onConfirm() {
+    action(commitment);
+  }
+
+  return (
+    <Modal
+      className="max-h-full"
+      title={title}
+      open={true}
+      modalFooter={
+        <BaseFooter onModalClose={onModalClose} guardFns={[checkInput]} actionFn={onConfirm} variant={"primary"} />
+      }
+      onCancel={() => {
+        onModalClose();
+      }}
+    >
+      <DataGrid columns={2} columnMaxSize="1fr">
+        <DataGridRow>
+          <DataGridCell className={label}>Availability Zone:</DataGridCell>
+          <DataGridCell>{availability_zone}</DataGridCell>
+        </DataGridRow>
+        <DataGridRow>
+          <DataGridCell className={label}>Amount:</DataGridCell>
+          <DataGridCell>{valueWithUnit(amount, unit)}</DataGridCell>
+        </DataGridRow>
+        <DataGridRow>
+          <DataGridCell className={label}>Duration:</DataGridCell>
+          <DataGridCell>{duration}</DataGridCell>
+        </DataGridRow>
+        <DataGridRow>
+          <DataGridCell>Expires at:</DataGridCell>
+          <DataGridCell>{formatTimeISO8160(expires_at)}</DataGridCell>
+        </DataGridRow>
+      </DataGrid>
+      <ConfirmInput subText={subText} {...inputProps} />
+    </Modal>
+  );
+};
+
+export default MarketplaceModal;

--- a/src/components/commitment/Modals/MarketplaceModal.test.js
+++ b/src/components/commitment/Modals/MarketplaceModal.test.js
@@ -19,6 +19,29 @@ import { PortalProvider } from "@cloudoperators/juno-ui-components/index";
 import { render, fireEvent, screen } from "@testing-library/react";
 import MarketplaceModal from "./MarketplaceModal";
 
+function mockGlobalStore(isProject, isCluster, isDomain) {
+  return jest.fn(() => ({
+    scope: {
+      isProject: jest.fn(() => isProject),
+      isCluster: jest.fn(() => isCluster),
+      isDomain: jest.fn(() => isDomain),
+    },
+  }));
+}
+
+function mockDomainStore(projects) {
+  return jest.fn(() => ({
+    projects,
+  }));
+}
+
+jest.mock("../../StoreProvider", () => {
+  return {
+    globalStore: jest.fn(),
+    domainStore: jest.fn(),
+  };
+});
+
 describe("MarketplaceModal", () => {
   const mockProps = {
     action: jest.fn(),
@@ -36,6 +59,10 @@ describe("MarketplaceModal", () => {
   };
 
   it("should render the modal with the correct content", () => {
+    const mockGlobalStoreInstance = mockGlobalStore(true, false, false);
+    const mockDomainStoreInstance = mockDomainStore([]);
+    require("../../StoreProvider").globalStore.mockImplementation(mockGlobalStoreInstance);
+    require("../../StoreProvider").domainStore.mockImplementation(mockDomainStoreInstance);
     render(
       <PortalProvider>
         <MarketplaceModal {...mockProps} />
@@ -49,6 +76,10 @@ describe("MarketplaceModal", () => {
   });
 
   it("should call the action function when the confirm button is clicked", () => {
+    const mockGlobalStoreInstance = mockGlobalStore(true, false, false);
+    const mockDomainStoreInstance = mockDomainStore([]);
+    require("../../StoreProvider").globalStore.mockImplementation(mockGlobalStoreInstance);
+    require("../../StoreProvider").domainStore.mockImplementation(mockDomainStoreInstance);
     render(
       <PortalProvider>
         <MarketplaceModal {...mockProps} />
@@ -62,6 +93,10 @@ describe("MarketplaceModal", () => {
   });
 
   it("should call the onModalClose function when the cancel button is clicked", () => {
+    const mockGlobalStoreInstance = mockGlobalStore(true, false, false);
+    const mockDomainStoreInstance = mockDomainStore([]);
+    require("../../StoreProvider").globalStore.mockImplementation(mockGlobalStoreInstance);
+    require("../../StoreProvider").domainStore.mockImplementation(mockDomainStoreInstance);
     render(
       <PortalProvider>
         <MarketplaceModal {...mockProps} />

--- a/src/components/commitment/Modals/MarketplaceModal.test.js
+++ b/src/components/commitment/Modals/MarketplaceModal.test.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components/index";
 import { render, fireEvent, screen } from "@testing-library/react";

--- a/src/components/commitment/Modals/MarketplaceModal.test.js
+++ b/src/components/commitment/Modals/MarketplaceModal.test.js
@@ -1,0 +1,57 @@
+import React from "react";
+import { PortalProvider } from "@cloudoperators/juno-ui-components/index";
+import { render, fireEvent, screen } from "@testing-library/react";
+import MarketplaceModal from "./MarketplaceModal";
+
+describe("MarketplaceModal", () => {
+  const mockProps = {
+    action: jest.fn(),
+    title: "Marketplace Commitment",
+    subText: "Receive",
+    onModalClose: jest.fn(),
+    commitment: {
+      id: "commitment-1",
+      amount: 100,
+      availability_zone: "az_1",
+      duration: "1 month",
+      expires_at: "0",
+      unit: "Gib",
+    },
+  };
+
+  it("should render the modal with the correct content", () => {
+    render(
+      <PortalProvider>
+        <MarketplaceModal {...mockProps} />
+      </PortalProvider>
+    );
+    expect(screen.getByText("Marketplace Commitment")).toBeInTheDocument();
+    expect(screen.getByText("az_1")).toBeInTheDocument();
+    expect(screen.getByText("100 Gib")).toBeInTheDocument();
+    expect(screen.getByText("1 month")).toBeInTheDocument();
+    expect(screen.getByText("1970-01-01")).toBeInTheDocument();
+  });
+
+  it("should call the action function when the confirm button is clicked", () => {
+    render(
+      <PortalProvider>
+        <MarketplaceModal {...mockProps} />
+      </PortalProvider>
+    );
+
+    const confirmInput = screen.getByTestId(/confirmInput/i);
+    fireEvent.change(confirmInput, { target: { value: "receive" } });
+    fireEvent.click(screen.getByText("Confirm"));
+    expect(mockProps.action).toHaveBeenCalled();
+  });
+
+  it("should call the onModalClose function when the cancel button is clicked", () => {
+    render(
+      <PortalProvider>
+        <MarketplaceModal {...mockProps} />
+      </PortalProvider>
+    );
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(mockProps.onModalClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/commitment/Modals/TransferCancelModal.js
+++ b/src/components/commitment/Modals/TransferCancelModal.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { Modal } from "@cloudoperators/juno-ui-components";
 import { TransferType } from "../../../lib/constants";

--- a/src/components/commitment/Modals/TransferCancelModal.js
+++ b/src/components/commitment/Modals/TransferCancelModal.js
@@ -1,0 +1,28 @@
+import React from "react";
+import { Modal } from "@cloudoperators/juno-ui-components";
+import { TransferType } from "../../../lib/constants";
+
+const TransferCancelModal = (props) => {
+  const { commitment, title, startCommitmentTransfer, onModalClose } = props;
+
+  return (
+    <Modal
+      title={title}
+      open={true}
+      confirmButtonLabel="Confirm"
+      onConfirm={() => {
+        startCommitmentTransfer(null, commitment, TransferType.NONE);
+      }}
+      cancelButtonLabel="Cancel"
+      onCancel={() => {
+        onModalClose();
+      }}
+    >
+      <div className={"mb-4 font-medium"}>
+        <div>Do you want to reset the commitment transfer state?</div>
+      </div>
+    </Modal>
+  );
+};
+
+export default TransferCancelModal;

--- a/src/components/commitment/Modals/TransferCancelModal.test.js
+++ b/src/components/commitment/Modals/TransferCancelModal.test.js
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2025 SAP SE
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
 import TransferCancelModal from "./TransferCancelModal";

--- a/src/components/commitment/Modals/TransferCancelModal.test.js
+++ b/src/components/commitment/Modals/TransferCancelModal.test.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { render, fireEvent, screen } from "@testing-library/react";
+import TransferCancelModal from "./TransferCancelModal";
+
+describe("TransferCancelModal", () => {
+  const mockProps = {
+    commitment: {
+      id: "commitment-123",
+      name: "Test Commitment",
+    },
+    title: "Transfer Commitment",
+    startCommitmentTransfer: jest.fn(),
+    onModalClose: jest.fn(),
+  };
+
+  test("should render the modal with the correct content", () => {
+    render(<TransferCancelModal {...mockProps} />);
+    expect(screen.getByText("Transfer Commitment")).toBeInTheDocument();
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+  });
+
+  test("should call the startCommitmentTransfer function when the confirm button is clicked", () => {
+    render(<TransferCancelModal {...mockProps} />);
+    fireEvent.click(screen.getByText("Confirm"));
+    expect(mockProps.startCommitmentTransfer).toHaveBeenCalledWith(null, mockProps.commitment, "");
+  });
+
+  test("should call the onModalClose function when the cancel button is clicked", () => {
+    render(<TransferCancelModal {...mockProps} />);
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(mockProps.onModalClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/commitment/Modals/TransferCancelModal.test.js
+++ b/src/components/commitment/Modals/TransferCancelModal.test.js
@@ -16,6 +16,7 @@
 
 import React from "react";
 import { render, fireEvent, screen } from "@testing-library/react";
+import { PortalProvider } from "@cloudoperators/juno-ui-components/index";
 import TransferCancelModal from "./TransferCancelModal";
 
 describe("TransferCancelModal", () => {
@@ -30,20 +31,32 @@ describe("TransferCancelModal", () => {
   };
 
   test("should render the modal with the correct content", () => {
-    render(<TransferCancelModal {...mockProps} />);
+    render(
+      <PortalProvider>
+        <TransferCancelModal {...mockProps} />
+      </PortalProvider>
+    );
     expect(screen.getByText("Transfer Commitment")).toBeInTheDocument();
     expect(screen.getByText("Confirm")).toBeInTheDocument();
     expect(screen.getByText("Cancel")).toBeInTheDocument();
   });
 
   test("should call the startCommitmentTransfer function when the confirm button is clicked", () => {
-    render(<TransferCancelModal {...mockProps} />);
+    render(
+      <PortalProvider>
+        <TransferCancelModal {...mockProps} />
+      </PortalProvider>
+    );
     fireEvent.click(screen.getByText("Confirm"));
     expect(mockProps.startCommitmentTransfer).toHaveBeenCalledWith(null, mockProps.commitment, "");
   });
 
   test("should call the onModalClose function when the cancel button is clicked", () => {
-    render(<TransferCancelModal {...mockProps} />);
+    render(
+      <PortalProvider>
+        <TransferCancelModal {...mockProps} />
+      </PortalProvider>
+    );
     fireEvent.click(screen.getByText("Cancel"));
     expect(mockProps.onModalClose).toHaveBeenCalled();
   });

--- a/src/components/commitment/Modals/TransferModal.js
+++ b/src/components/commitment/Modals/TransferModal.js
@@ -34,16 +34,23 @@ import { TransferType } from "../../../lib/constants";
 
 const label = "font-semibold";
 
+// The TransferModal displays the commitment transfer action for certain conditions.
+// Project level: Allows the set the target commitment into a private or public transfer state (private transfer or marketplace posting).
+// Cluster/Domain level: Allows to start and transfer the commitment in a single action.
+// Cluster/Domain level: Allows to set the target commitment into a public transfer state (marketplace posting).
 const TransferModal = (props) => {
   const { title, subText, onModalClose, onTransfer, currentProject, transferProject, commitment, isProjectView } =
     props;
   const { metadata: originMeta } = currentProject || {};
   const { metadata: targetMeta } = transferProject || {};
+  const isPrivateTransferAction = !isProjectView && transferProject ? true : false;
   const unit = new Unit(commitment.unit);
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
     confirmationText: subText,
   });
-  const [publicationType, setPublicationType] = React.useState(TransferType.UNLISTED);
+  const [publicationType, setPublicationType] = React.useState(
+    isProjectView || isPrivateTransferAction ? TransferType.UNLISTED : TransferType.PUBLIC
+  );
   const [splitCommitment, setSplitCommitment] = React.useState(false);
   const [invalidSplitInput, setInvalidSplitInput] = React.useState(false);
   const splitInputRef = React.useRef(unit.format(commitment.amount, { ascii: true }));
@@ -84,13 +91,13 @@ const TransferModal = (props) => {
           <DataGridCell className={label}>Duration:</DataGridCell>
           <DataGridCell>{commitment.duration}</DataGridCell>
         </DataGridRow>
-        {!isProjectView && (
+        {isPrivateTransferAction && (
           <DataGridRow>
             <DataGridCell className={label}>Origin:</DataGridCell>
             <DataGridCell>{originMeta?.name}</DataGridCell>
           </DataGridRow>
         )}
-        {!isProjectView && (
+        {isPrivateTransferAction && (
           <DataGridRow>
             <DataGridCell className={label}>Target:</DataGridCell>
             <DataGridCell>{targetMeta?.name}</DataGridCell>
@@ -107,12 +114,12 @@ const TransferModal = (props) => {
               label="Transfer only a part."
             />
           </DataGridCell>
-          {isProjectView && (
-            <DataGridRow>
-              <DataGridCell className={label}>Publication type:</DataGridCell>
-              <DataGridCell>
+          <DataGridRow>
+            <DataGridCell className={label}>Publication type:</DataGridCell>
+            <DataGridCell>
+              {isProjectView ? (
                 <Select
-                  defaultValue={TransferType.UNLISTED}
+                  defaultValue={isProjectView ? TransferType.UNLISTED : TransferType.PUBLIC}
                   onChange={(value) => {
                     setPublicationType(value);
                   }}
@@ -120,9 +127,11 @@ const TransferModal = (props) => {
                   <SelectOption value={TransferType.UNLISTED} label="Private" />
                   <SelectOption value={TransferType.PUBLIC} label="Marketplace" />
                 </Select>
-              </DataGridCell>
-            </DataGridRow>
-          )}
+              ) : (
+                "Marketplace"
+              )}
+            </DataGridCell>
+          </DataGridRow>
         </DataGridRow>
       </DataGrid>
       <Stack direction="vertical" alignment="center" className="mb-1 mt-5">

--- a/src/components/commitment/Modals/TransferModal.js
+++ b/src/components/commitment/Modals/TransferModal.js
@@ -21,13 +21,16 @@ import {
   DataGridRow,
   DataGridCell,
   Checkbox,
+  Select,
   Stack,
   TextInput,
+  SelectOption,
 } from "@cloudoperators/juno-ui-components";
 import BaseFooter from "./BaseComponents/BaseFooter";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
 import { valueWithUnit } from "../../../lib/unit";
 import { Unit } from "../../../lib/unit";
+import { TransferType } from "../../../lib/constants";
 
 const label = "font-semibold";
 
@@ -40,6 +43,7 @@ const TransferModal = (props) => {
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
     confirmationText: subText,
   });
+  const [publicationType, setPublicationType] = React.useState(TransferType.UNLISTED);
   const [splitCommitment, setSplitCommitment] = React.useState(false);
   const [invalidSplitInput, setInvalidSplitInput] = React.useState(false);
   const splitInputRef = React.useRef(unit.format(commitment.amount, { ascii: true }));
@@ -58,7 +62,7 @@ const TransferModal = (props) => {
       }
       commitment.amount = parsedInput;
     }
-    onTransfer(transferProject, commitment);
+    onTransfer(transferProject, commitment, publicationType);
   }
 
   return (
@@ -103,6 +107,22 @@ const TransferModal = (props) => {
               label="Transfer only a part."
             />
           </DataGridCell>
+          {isProjectView && (
+            <DataGridRow>
+              <DataGridCell className={label}>Publication type:</DataGridCell>
+              <DataGridCell>
+                <Select
+                  defaultValue={TransferType.UNLISTED}
+                  onChange={(value) => {
+                    setPublicationType(value);
+                  }}
+                >
+                  <SelectOption value={TransferType.UNLISTED} label="Private" />
+                  <SelectOption value={TransferType.PUBLIC} label="Marketplace" />
+                </Select>
+              </DataGridCell>
+            </DataGridRow>
+          )}
         </DataGridRow>
       </DataGrid>
       <Stack direction="vertical" alignment="center" className="mb-1 mt-5">

--- a/src/components/commitment/Modals/TransferModal.js
+++ b/src/components/commitment/Modals/TransferModal.js
@@ -114,24 +114,27 @@ const TransferModal = (props) => {
               label="Transfer only a part."
             />
           </DataGridCell>
-          <DataGridRow>
-            <DataGridCell className={label}>Publication type:</DataGridCell>
-            <DataGridCell>
-              {isProjectView ? (
-                <Select
-                  defaultValue={isProjectView ? TransferType.UNLISTED : TransferType.PUBLIC}
-                  onChange={(value) => {
-                    setPublicationType(value);
-                  }}
-                >
-                  <SelectOption value={TransferType.UNLISTED} label="Private" />
-                  <SelectOption value={TransferType.PUBLIC} label="Marketplace" />
-                </Select>
-              ) : (
-                "Marketplace"
-              )}
-            </DataGridCell>
-          </DataGridRow>
+          {!transferProject && (
+            <DataGridRow>
+              <DataGridCell className={label}>Publication type:</DataGridCell>
+              <DataGridCell>
+                {isProjectView ? (
+                  <Select
+                    data-testid="publicationSelect"
+                    defaultValue={isProjectView ? TransferType.UNLISTED : TransferType.PUBLIC}
+                    onChange={(value) => {
+                      setPublicationType(value);
+                    }}
+                  >
+                    <SelectOption value={TransferType.UNLISTED} label="Private" />
+                    <SelectOption value={TransferType.PUBLIC} label="Marketplace" />
+                  </Select>
+                ) : (
+                  "Marketplace"
+                )}
+              </DataGridCell>
+            </DataGridRow>
+          )}
         </DataGridRow>
       </DataGrid>
       <Stack direction="vertical" alignment="center" className="mb-1 mt-5">

--- a/src/components/commitment/Modals/TransferModal.test.js
+++ b/src/components/commitment/Modals/TransferModal.test.js
@@ -17,13 +17,13 @@
 import React from "react";
 import TransferModal from "./TransferModal";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { initialCommitmentObject } from "../../../lib/constants";
 
 describe("test transfer modal", () => {
   const onCancel = jest.fn(() => {});
 
-  test("project level: transfer whole commitment", () => {
+  test("project level: transfer whole commitment", async () => {
     const onTransfer = jest.fn((transferProject, commitment) => {
       expect(transferProject).toBeFalsy();
       expect(commitment.amount).toEqual(10);
@@ -50,7 +50,9 @@ describe("test transfer modal", () => {
     expect(screen.getByText(10)).toBeInTheDocument();
     expect(screen.getByText("1 year")).toBeInTheDocument();
     fireEvent.change(confirmInput, { target: { value: "wrongInput" } });
-    expect(onTransfer).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).not.toHaveBeenCalled();
+    });
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
     expect(onTransfer).toHaveBeenCalled();

--- a/src/components/commitment/Modals/TransferModal.test.js
+++ b/src/components/commitment/Modals/TransferModal.test.js
@@ -18,7 +18,7 @@ import React from "react";
 import TransferModal from "./TransferModal";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { initialCommitmentObject } from "../../../lib/constants";
+import { initialCommitmentObject, TransferType } from "../../../lib/constants";
 
 describe("test transfer modal", () => {
   const onCancel = jest.fn(() => {});
@@ -58,7 +58,7 @@ describe("test transfer modal", () => {
     expect(onTransfer).toHaveBeenCalled();
   });
 
-  test("domain/cluster level: transfer part of a commitment", () => {
+  test("Cluster/Domain level: transfer part of a commitment", () => {
     const onTransfer = jest.fn((transferProject, commitment) => {
       expect(transferProject).toBeTruthy();
       expect(commitment.amount).toEqual(5);
@@ -93,6 +93,135 @@ describe("test transfer modal", () => {
     });
     const splitInput = screen.getByTestId(/splitInput/i);
     fireEvent.change(splitInput, { target: { value: 5 } });
+    fireEvent.change(confirmInput, { target: { value: "transfer" } });
+    fireEvent.click(confirmButton);
+    expect(onTransfer).toHaveBeenCalled();
+  });
+
+  test("check marketplace options", async () => {
+    let isProjectView = false;
+    let transferProject = { metadata: { name: "targetProject" } };
+    const confirmedCommitment = { ...initialCommitmentObject };
+    confirmedCommitment.amount = 10;
+    confirmedCommitment.duration = "1 year";
+    let onTransfer = jest.fn((transferProject, commitment, publicationType) => {
+      expect(publicationType).toEqual(TransferType.UNLISTED);
+      expect(transferProject).toBeTruthy();
+      expect(commitment.amount).toEqual(10);
+      expect(commitment.duration).toEqual("1 year");
+    });
+    const { unmount: unmountMoveAction } = render(
+      <PortalProvider>
+        <TransferModal
+          title="Transfer Commitment"
+          subText="Transfer"
+          commitment={confirmedCommitment}
+          onTransfer={onTransfer}
+          isProjectView={isProjectView}
+          currentProject={{ metadata: { name: "sourceProject" } }}
+          transferProject={transferProject}
+        />
+      </PortalProvider>
+    );
+
+    // Cluster/Domain level: Execute a private transfer with the move action
+    let confirmButton = screen.getByTestId(/modalConfirm/i);
+    let confirmInput = screen.getByTestId(/confirmInput/i);
+    expect(screen.queryByTestId("publicationSelect")).not.toBeInTheDocument();
+    expect(screen.queryByText(/marketplace/i)).not.toBeInTheDocument();
+    fireEvent.change(confirmInput, { target: { value: "transfer" } });
+    fireEvent.click(confirmButton);
+    expect(onTransfer).toHaveBeenCalled();
+    unmountMoveAction();
+
+    // Cluster/Domain level: Transfers to the marketplace, private transfers are performed using the move action.
+    transferProject = null;
+    onTransfer = jest.fn((transferProject, commitment, publicationType) => {
+      expect(publicationType).toEqual(TransferType.PUBLIC);
+      expect(transferProject).toBeFalsy();
+      expect(commitment.amount).toEqual(10);
+      expect(commitment.duration).toEqual("1 year");
+    });
+    const { unmount: unmountMarketPlaceAction } = render(
+      <PortalProvider>
+        <TransferModal
+          title="Transfer Commitment"
+          subText="Transfer"
+          commitment={confirmedCommitment}
+          onTransfer={onTransfer}
+          isProjectView={isProjectView}
+          currentProject={{ metadata: { name: "sourceProject" } }}
+          transferProject={transferProject}
+        />
+      </PortalProvider>
+    );
+    confirmButton = screen.getByTestId(/modalConfirm/i);
+    confirmInput = screen.getByTestId(/confirmInput/i);
+    expect(screen.queryByTestId("publicationSelect")).not.toBeInTheDocument();
+    expect(screen.queryByText(/marketplace/i)).toBeInTheDocument();
+    fireEvent.change(confirmInput, { target: { value: "transfer" } });
+    fireEvent.click(confirmButton);
+    expect(onTransfer).toHaveBeenCalled();
+    unmountMarketPlaceAction();
+
+    // Project level: Contains the selection between private and public transfers.
+    isProjectView = true;
+    onTransfer = jest.fn((transferProject, commitment, publicationType) => {
+      expect(publicationType).toEqual(TransferType.UNLISTED);
+      expect(transferProject).toBeFalsy();
+      expect(commitment.amount).toEqual(10);
+      expect(commitment.duration).toEqual("1 year");
+    });
+    const { rerender } = render(
+      <PortalProvider>
+        <TransferModal
+          title="Transfer Commitment"
+          subText="Transfer"
+          commitment={confirmedCommitment}
+          onTransfer={onTransfer}
+          isProjectView={isProjectView}
+          currentProject={{ metadata: { name: "sourceProject" } }}
+          transferProject={transferProject}
+        />
+      </PortalProvider>
+    );
+    let selectElement = screen.getByTestId("publicationSelect");
+    await waitFor(() => {
+      expect(selectElement).toHaveTextContent("Private");
+    });
+    expect(screen.queryByTestId("publicationSelect")).toBeInTheDocument();
+    confirmButton = screen.getByTestId(/modalConfirm/i);
+    confirmInput = screen.getByTestId(/confirmInput/i);
+    fireEvent.change(confirmInput, { target: { value: "transfer" } });
+    fireEvent.click(confirmButton);
+    expect(onTransfer).toHaveBeenCalled();
+
+    onTransfer = jest.fn((transferProject, commitment, publicationType) => {
+      expect(publicationType).toEqual(TransferType.PUBLIC);
+      expect(transferProject).toBeFalsy();
+      expect(commitment.amount).toEqual(10);
+      expect(commitment.duration).toEqual("1 year");
+    });
+    rerender(
+      <PortalProvider>
+        <TransferModal
+          title="Transfer Commitment"
+          subText="Transfer"
+          commitment={confirmedCommitment}
+          onTransfer={onTransfer}
+          isProjectView={isProjectView}
+          currentProject={{ metadata: { name: "sourceProject" } }}
+          transferProject={transferProject}
+        />
+      </PortalProvider>
+    );
+    expect(screen.queryByTestId("publicationSelect")).toBeInTheDocument();
+    selectElement = screen.getByTestId("publicationSelect");
+    confirmButton = screen.getByTestId(/modalConfirm/i);
+    confirmInput = screen.getByTestId(/confirmInput/i);
+    fireEvent.mouseDown(selectElement);
+    const marketplaceOption = screen.getByText("Marketplace");
+    fireEvent.click(marketplaceOption);
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
     expect(onTransfer).toHaveBeenCalled();

--- a/src/components/commitment/Modals/UpdateDurationModal.js
+++ b/src/components/commitment/Modals/UpdateDurationModal.js
@@ -32,6 +32,8 @@ const UpdateDurationModal = (props) => {
   const { validDurations: durations } = createCommitmentStore();
   const validDurations = durations.get(commitment.id) || [];
 
+  console.log(commitment);
+
   function onConfirm() {
     if (!selectedDuration) {
       return;

--- a/src/components/commitment/Modals/UpdateDurationModal.js
+++ b/src/components/commitment/Modals/UpdateDurationModal.js
@@ -32,8 +32,6 @@ const UpdateDurationModal = (props) => {
   const { validDurations: durations } = createCommitmentStore();
   const validDurations = durations.get(commitment.id) || [];
 
-  console.log(commitment);
-
   function onConfirm() {
     if (!selectedDuration) {
       return;

--- a/src/components/commitment/Operations/Actions.js
+++ b/src/components/commitment/Operations/Actions.js
@@ -60,7 +60,11 @@ const Actions = (props) => {
             content={commitmentActions.map((action) => {
               const toolTip = action.toolTip;
               if (toolTip == null) return;
-              return <div key={action.key}>{toolTip}</div>;
+              return (
+                <span key={action.key}>
+                  {toolTip} <br />
+                </span>
+              );
             })}
           />
         )}

--- a/src/components/commitment/Operations/Actions.js
+++ b/src/components/commitment/Operations/Actions.js
@@ -40,9 +40,13 @@ const Actions = (props) => {
 
   function updateActions(key, menuItem, toolTip) {
     const newAction = { key: key, menuItem: menuItem, toolTip: toolTip };
-    setCommitmentActions((commitmentActions) =>
-      [...commitmentActions, newAction].sort((a, b) => a.key.localeCompare(b.key))
-    );
+
+    setCommitmentActions((commitmentActions) => {
+      return commitmentActions
+        .filter((action) => action.key !== key)
+        .concat(newAction)
+        .sort((a, b) => a.key.localeCompare(b.key));
+    });
   }
 
   useConversionAction({ commitment, updateActions });

--- a/src/components/commitment/Operations/Actions.test.js
+++ b/src/components/commitment/Operations/Actions.test.js
@@ -107,7 +107,7 @@ describe("test Action Operation", () => {
         </StoreProvider>
       </PortalProvider>
     );
-    const { result } = await waitFor(() => {
+    const { result, rerender } = await waitFor(() => {
       return renderHook(
         () => ({
           commitmentStore: createCommitmentStore(),
@@ -130,6 +130,17 @@ describe("test Action Operation", () => {
     userEvent.click(contextMenu);
     await waitFor(() => {
       expect(screen.queryByText(/transfer/i)).not.toBe(null);
+    });
+
+    rerender();
+    commitment.transfer_status = "public";
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+    userEvent.click(contextMenu);
+    await waitFor(() => {
+      expect(screen.queryByText(/transferring/i)).not.toBe(null);
+      expect(screen.queryByText(/cancel transfer/i)).not.toBe(null);
     });
   });
   test("should render duration update action", async () => {

--- a/src/components/commitment/Operations/useTransferAction.js
+++ b/src/components/commitment/Operations/useTransferAction.js
@@ -21,12 +21,13 @@ import { globalStore, createCommitmentStoreActions } from "../../StoreProvider";
 
 const useTransferAction = (props) => {
   const { commitment, updateActions } = props;
-  const commitmentInTrasfer = commitment.transfer_status ? true : false;
+  const { transfer_status: transferStatus } = commitment;
+  const commitmentInTrasfer = transferStatus ? true : false;
   const { scope } = globalStore();
   const { setTransferredCommitment } = createCommitmentStoreActions();
   const { setTransferFromAndToProject } = createCommitmentStoreActions();
 
-  function transferCommitOnProjectLevel() {
+  function transferCommitment() {
     setTransferFromAndToProject(commitmentInTrasfer ? TransferStatus.VIEW : TransferStatus.START);
     setTransferredCommitment(commitment);
   }
@@ -37,23 +38,17 @@ const useTransferAction = (props) => {
   }
 
   React.useEffect(() => {
-    if (!scope.isProject()) return;
-    const menuItem = (
-      <MenuItemBuilder
-        icon="upload"
-        text={commitmentInTrasfer ? "Transferring" : "Transfer"}
-        callBack={transferCommitOnProjectLevel}
-      />
-    );
-    let toolTip = null;
-    if (commitmentInTrasfer) {
-      toolTip = "ready for transfer";
+    const toolTip = commitmentInTrasfer ? "ready for transfer" : null;
+    let transferText = commitmentInTrasfer ? "Transferring" : "Transfer";
+    if (!scope.isProject() && !commitmentInTrasfer) {
+      transferText = `${transferText} (Marketplace)`;
     }
+    const menuItem = <MenuItemBuilder icon="upload" text={transferText} callBack={transferCommitment} />;
     updateActions("transfer", menuItem, toolTip);
 
     if (!commitmentInTrasfer) return;
     const cancelTransferMenuItem = (
-      <MenuItemBuilder icon="close" text="Cancel transfer" callBack={cancelTransferCommitment} />
+      <MenuItemBuilder icon="close" text={"Cancel transfer"} callBack={cancelTransferCommitment} />
     );
     updateActions("cancel_transfer", cancelTransferMenuItem, null);
   }, [commitment, scope]);

--- a/src/components/commitment/Operations/useTransferAction.js
+++ b/src/components/commitment/Operations/useTransferAction.js
@@ -22,7 +22,6 @@ import { globalStore, createCommitmentStoreActions } from "../../StoreProvider";
 const useTransferAction = (props) => {
   const { commitment, updateActions } = props;
   const commitmentInTrasfer = commitment.transfer_status ? true : false;
-  const { confirmed_at: isConfirmed } = commitment;
   const { scope } = globalStore();
   const { setTransferredCommitment } = createCommitmentStoreActions();
   const { setTransferFromAndToProject } = createCommitmentStoreActions();
@@ -33,7 +32,7 @@ const useTransferAction = (props) => {
   }
 
   React.useEffect(() => {
-    if (scope.isProject() && isConfirmed) {
+    if (scope.isProject()) {
       const menuItem = (
         <MenuItemBuilder
           icon="upload"
@@ -47,7 +46,7 @@ const useTransferAction = (props) => {
       }
       updateActions("transfer", menuItem, toolTip);
     }
-  }, [isConfirmed, scope]);
+  }, [commitment, scope]);
 };
 
 export default useTransferAction;

--- a/src/components/commitment/Operations/useTransferAction.js
+++ b/src/components/commitment/Operations/useTransferAction.js
@@ -31,21 +31,31 @@ const useTransferAction = (props) => {
     setTransferredCommitment(commitment);
   }
 
+  function cancelTransferCommitment() {
+    setTransferFromAndToProject(TransferStatus.CANCEL);
+    setTransferredCommitment(commitment);
+  }
+
   React.useEffect(() => {
-    if (scope.isProject()) {
-      const menuItem = (
-        <MenuItemBuilder
-          icon="upload"
-          text={commitmentInTrasfer ? "Transferring" : "Transfer"}
-          callBack={transferCommitOnProjectLevel}
-        />
-      );
-      let toolTip = null;
-      if (commitmentInTrasfer) {
-        toolTip = "ready for transfer";
-      }
-      updateActions("transfer", menuItem, toolTip);
+    if (!scope.isProject()) return;
+    const menuItem = (
+      <MenuItemBuilder
+        icon="upload"
+        text={commitmentInTrasfer ? "Transferring" : "Transfer"}
+        callBack={transferCommitOnProjectLevel}
+      />
+    );
+    let toolTip = null;
+    if (commitmentInTrasfer) {
+      toolTip = "ready for transfer";
     }
+    updateActions("transfer", menuItem, toolTip);
+
+    if (!commitmentInTrasfer) return;
+    const cancelTransferMenuItem = (
+      <MenuItemBuilder icon="close" text="Cancel transfer" callBack={cancelTransferCommitment} />
+    );
+    updateActions("cancel_transfer", cancelTransferMenuItem, null);
   }, [commitment, scope]);
 };
 

--- a/src/components/domain/DomainManager.js
+++ b/src/components/domain/DomainManager.js
@@ -20,7 +20,7 @@ import { clusterStore, clusterStoreActions } from "../StoreProvider";
 import ProjectsPerDomain from "./ProjectsPerDomain";
 
 const DomainManager = (props) => {
-  const { serviceType, currentCategory, currentResource, currentAZ, subRoute, sortProjectProps, mergeOps } = props;
+  const { serviceType, currentCategory, currentResource, currentTab, subRoute, sortProjectProps, mergeOps } = props;
   const { domainData } = clusterStore();
   const { setDomainData } = clusterStoreActions();
   const domainQueryResult = useQuery({ queryKey: ["domains", "", ""] });
@@ -41,7 +41,7 @@ const DomainManager = (props) => {
         resource={currentResource}
         domains={domainData}
         currentCategory={currentCategory}
-        currentAZ={currentAZ}
+        currentTab={currentTab}
         subRoute={subRoute}
         sortProjectProps={sortProjectProps}
         mergeOps={mergeOps}

--- a/src/components/domain/ProjectsPerDomain.js
+++ b/src/components/domain/ProjectsPerDomain.js
@@ -29,7 +29,7 @@ import { LoadingIndicator } from "@cloudoperators/juno-ui-components";
 
 const ProjectsPerDomain = (props) => {
   // Fetch project data for all domains
-  const { domains, serviceType, currentCategory, resource, currentAZ, subRoute, sortProjectProps, mergeOps } = props;
+  const { domains, serviceType, currentCategory, resource, currentTab, subRoute, sortProjectProps, mergeOps } = props;
   const { enableSortActivities } = sortProjectProps;
   const resourceName = resource.name;
   const { restructureReport } = globalStoreActions();
@@ -95,7 +95,7 @@ const ProjectsPerDomain = (props) => {
       serviceType={serviceType}
       currentResource={resource}
       currentCategory={currentCategory}
-      currentAZ={currentAZ}
+      currentTab={currentTab}
       projects={projects}
       subRoute={subRoute}
       sortProjectProps={sortProjectProps}

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -87,7 +87,7 @@ const Resource = (props) => {
     resource,
     isPanelView,
     subRoute,
-    setCurrentAZ,
+    setCurrentTab,
     serviceType,
     setIsMerging,
     tracksQuota,
@@ -198,7 +198,7 @@ const Resource = (props) => {
                 }`}
                 onClick={() => {
                   if (!props.isPanelView || subRoute || azName == "unknown") return;
-                  setCurrentAZ(azName);
+                  setCurrentTab(azName);
                   setIsMerging(false);
                   resetCommitment();
                 }}

--- a/src/components/panel/AvailabilityZoneNav.js
+++ b/src/components/panel/AvailabilityZoneNav.js
@@ -48,7 +48,7 @@ const AvailabilityZoneNav = (props) => {
   }
 
   return (
-    <Container px={false} className="pt-0 py-6 sticky top-[2rem] z-[100]">
+    <Container px={false} className="pt-0 py-6 sticky top-[2rem] bg-theme-background-lvl-0 z-[100]">
       <Tabs selectedIndex={azIndex} onSelect={() => {}}>
         <TabList>
           {tabs.map((tabName) => {

--- a/src/components/panel/AvailabilityZoneNav.js
+++ b/src/components/panel/AvailabilityZoneNav.js
@@ -45,7 +45,7 @@ const AvailabilityZoneNav = (props) => {
   }
 
   return (
-    <Container px={false} className="pt-0 py-6 sticky top-[2rem] bg-juno-grey-light-1 z-[100]">
+    <Container px={false} className="pt-0 py-6 sticky top-[2rem] z-[100]">
       <Tabs selectedIndex={azIndex} onSelect={() => {}}>
         <TabList>
           {tabs.map((tabName) => {

--- a/src/components/panel/AvailabilityZoneNav.js
+++ b/src/components/panel/AvailabilityZoneNav.js
@@ -17,14 +17,17 @@
 import React from "react";
 import AddCommitments from "../shared/AddCommitments";
 import ReceiveCommitment from "./ReceiveCommitment";
-import { Stack, Tabs, Tab, TabList, TabPanel, Container } from "@cloudoperators/juno-ui-components";
+import { Stack, Tabs, Tab, TabList, TabPanel, Container, Icon } from "@cloudoperators/juno-ui-components";
 import useResetCommitment from "../../hooks/useResetCommitment";
 import MergeCommitment from "../shared/MergeCommitments";
+import ToolTipWrapper from "../shared/ToolTipWrapper";
 import { CustomZones } from "../../lib/constants";
 import { isAZUnaware } from "../../lib/utils";
 
 const AvailabilityZoneNav = (props) => {
-  const { scope, resource, currentTab, setCurrentTab, mergeOps } = props;
+  const { scope, resource, currentTab, setCurrentTab, mergeOps, publicCommitmentQuery } = props;
+  const { data } = publicCommitmentQuery;
+  const publicCommitments = data?.commitments || [];
   const { setIsMerging, setCommitmentsToMerge } = mergeOps;
   const { resetCommitment } = useResetCommitment();
   const tabs = React.useMemo(() => {
@@ -33,7 +36,7 @@ const AvailabilityZoneNav = (props) => {
     const azNames = azs
       .map((az) => az.name)
       .filter((name) => name !== CustomZones.UNKNOWN)
-      .filter((name) => !azUnaware ? name !== CustomZones.ANY : true);
+      .filter((name) => (!azUnaware ? name !== CustomZones.ANY : true));
     return scope.isProject() ? [...azNames, CustomZones.MARKETPLACE] : azNames;
   }, [resource]);
   const azIndex = tabs.findIndex((tabName) => tabName === currentTab) || 0;
@@ -59,6 +62,12 @@ const AvailabilityZoneNav = (props) => {
                 }}
               >
                 {tabName}
+                {tabName == CustomZones.MARKETPLACE && publicCommitments.length > 0 && (
+                  <ToolTipWrapper
+                    trigger={<Icon className="mt-auto ml-1" size="16" icon="info" />}
+                    content={<span className="font-normal">{publicCommitments.length} available.</span>}
+                  />
+                )}
               </Tab>
             );
           })}

--- a/src/components/panel/AvailabilityZoneNav.js
+++ b/src/components/panel/AvailabilityZoneNav.js
@@ -38,7 +38,7 @@ const AvailabilityZoneNav = (props) => {
       .filter((name) => name !== CustomZones.UNKNOWN)
       .filter((name) => (!azUnaware ? name !== CustomZones.ANY : true));
     return scope.isProject() ? [...azNames, CustomZones.MARKETPLACE] : azNames;
-  }, [resource]);
+  }, [scope, resource]);
   const azIndex = tabs.findIndex((tabName) => tabName === currentTab) || 0;
 
   function handleTabSelect() {
@@ -64,7 +64,14 @@ const AvailabilityZoneNav = (props) => {
                 {tabName}
                 {tabName == CustomZones.MARKETPLACE && publicCommitments.length > 0 && (
                   <ToolTipWrapper
-                    trigger={<Icon className="mt-auto ml-1" size="16" icon="info" />}
+                    trigger={
+                      <Icon
+                        data-testid={`MarketplaceInfoCount:${publicCommitments.length}`}
+                        className="mt-auto ml-1"
+                        size="16"
+                        icon="info"
+                      />
+                    }
                     content={<span className="font-normal">{publicCommitments.length} available.</span>}
                   />
                 )}

--- a/src/components/panel/AvailabilityZoneNav.js
+++ b/src/components/panel/AvailabilityZoneNav.js
@@ -18,6 +18,7 @@ import React from "react";
 import AddCommitments from "../shared/AddCommitments";
 import ReceiveCommitment from "./ReceiveCommitment";
 import { Stack, Tabs, Tab, TabList, TabPanel, Container, Icon } from "@cloudoperators/juno-ui-components";
+import { domainStore } from "../StoreProvider";
 import useResetCommitment from "../../hooks/useResetCommitment";
 import MergeCommitment from "../shared/MergeCommitments";
 import ToolTipWrapper from "../shared/ToolTipWrapper";
@@ -30,6 +31,7 @@ const AvailabilityZoneNav = (props) => {
   const publicCommitments = data?.commitments || [];
   const { setIsMerging, setCommitmentsToMerge } = mergeOps;
   const { resetCommitment } = useResetCommitment();
+  const { projects } = domainStore();
   const tabs = React.useMemo(() => {
     const { per_az: azs } = resource;
     const azUnaware = isAZUnaware(azs);
@@ -37,7 +39,7 @@ const AvailabilityZoneNav = (props) => {
       .map((az) => az.name)
       .filter((name) => name !== CustomZones.UNKNOWN)
       .filter((name) => (!azUnaware ? name !== CustomZones.ANY : true));
-    return scope.isProject() ? [...azNames, CustomZones.MARKETPLACE] : azNames;
+    return [...azNames, CustomZones.MARKETPLACE];
   }, [scope, resource]);
   const azIndex = tabs.findIndex((tabName) => tabName === currentTab) || 0;
 
@@ -55,6 +57,7 @@ const AvailabilityZoneNav = (props) => {
             return (
               <Tab
                 data-testid={`tab/${tabName}`}
+                disabled={!scope.isProject() && !projects}
                 key={tabName}
                 onClick={() => {
                   setCurrentTab(tabName);

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -388,7 +388,7 @@ const EditPanel = (props) => {
         setCurrentTab={setCurrentTab}
         tracksQuota={tracksQuota}
       />
-      <div className={"sticky top-0 z-[100] h-8"}>
+      <div className={"sticky top-0 z-[100] bg-theme-background-lvl-0 h-8"}>
         {toast.message && (
           <Toast className={"pb-0"} text={toast.message} variant={toast.variant} onDismiss={() => dismissToast()} />
         )}

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -400,7 +400,7 @@ const EditPanel = (props) => {
             scope={scope}
           />
         ) : (
-          <Marketplace />
+          <Marketplace serviceType={serviceType} resource={currentResource} />
         ))}
       {scope.isDomain() && (
         <ProjectManager

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -195,7 +195,9 @@ const EditPanel = (props) => {
             resetCommitmentTransfer();
             setRefetchProjectAPI(true);
             setRefetchCommitmentAPI(true);
-            publicCommitmentQuery.refetch();
+            if (transferType == TransferType.PUBLIC) {
+              publicCommitmentQuery.refetch();
+            }
             return;
           }
           const receivedCommitment = data.commitment;
@@ -215,6 +217,7 @@ const EditPanel = (props) => {
     // Cluster View targets the custom field domainID. It is set in the cluster project handling logic.
     const targetDomainID = project?.metadata.domainID || null;
     const targetProjectID = project.metadata.id;
+    const transferStatus = commitment?.transfer_status || null;
 
     transfer.mutate(
       {
@@ -231,7 +234,9 @@ const EditPanel = (props) => {
           setRefetchProjectAPI(true);
           setRefetchCommitmentAPI(true);
           setTransferProject(null);
-          scope.isProject() && publicCommitmentQuery.refetch();
+          if (scope.isProject() && transferStatus == TransferType.PUBLIC) {
+            publicCommitmentQuery.refetch();
+          }
         },
         onError: (error) => {
           resetCommitmentTransfer();
@@ -407,7 +412,12 @@ const EditPanel = (props) => {
             scope={scope}
           />
         ) : (
-          <Marketplace resource={currentResource} publicCommitmentQuery={publicCommitmentQuery} />
+          <Marketplace
+            project={currentProject}
+            resource={currentResource}
+            publicCommitmentQuery={publicCommitmentQuery}
+            transferCommitment={transferCommitment}
+          />
         ))}
       {scope.isDomain() && (
         <ProjectManager

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -386,7 +386,7 @@ const EditPanel = (props) => {
           mergeOps={mergeForwardProps}
         />
       )}
-      {scope.isProject() && commitments && (
+      {scope.isProject() && (
         <CommitmentTable
           serviceType={serviceType}
           currentCategory={currentCategory}

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -43,6 +43,7 @@ import useGetConversions from "./PanelHooks/useGetConversions";
 import useResetCommitment from "../../hooks/useResetCommitment";
 import { CustomZones, initialCommitmentObject, TransferStatus, TransferType } from "../../lib/constants";
 import Marketplace from "../commitment/Marketplace";
+import TransferCancelModal from "../commitment/Modals/TransferCancelModal";
 
 const EditPanel = (props) => {
   const { scope } = globalStore();
@@ -195,7 +196,10 @@ const EditPanel = (props) => {
             resetCommitmentTransfer();
             setRefetchProjectAPI(true);
             setRefetchCommitmentAPI(true);
-            if (transferType == TransferType.PUBLIC) {
+            if (
+              transferType == TransferType.PUBLIC ||
+              (transferType == TransferType.NONE && commitment?.transfer_status == TransferType.PUBLIC)
+            ) {
               publicCommitmentQuery.refetch();
             }
             return;
@@ -490,6 +494,14 @@ const EditPanel = (props) => {
           serviceType={serviceType}
           currentResource={currentResource}
           transferCommitment={transferCommitment}
+          onModalClose={onTransferModalProjectClose}
+        />
+      )}
+      {scope.isProject() && transferFromAndToProject == TransferStatus.CANCEL && (
+        <TransferCancelModal
+          title="Cancel transfer state"
+          commitment={transferredCommitment}
+          startCommitmentTransfer={startCommitmentTransfer}
           onModalClose={onTransferModalProjectClose}
         />
       )}

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -372,7 +372,7 @@ const EditPanel = (props) => {
         setCurrentTab={setCurrentTab}
         tracksQuota={tracksQuota}
       />
-      <div className={"sticky top-0 z-[100] bg-juno-grey-light-1 h-8"}>
+      <div className={"sticky top-0 z-[100] h-8"}>
         {toast.message && (
           <Toast className={"pb-0"} text={toast.message} variant={toast.variant} onDismiss={() => dismissToast()} />
         )}

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -41,7 +41,8 @@ import ProjectManager from "../project/ProjectManager";
 import DomainManager from "../domain/DomainManager";
 import useGetConversions from "./PanelHooks/useGetConversions";
 import useResetCommitment from "../../hooks/useResetCommitment";
-import { initialCommitmentObject, TransferStatus } from "../../lib/constants";
+import { CustomZones, initialCommitmentObject, TransferStatus } from "../../lib/constants";
+import Marketplace from "../commitment/Marketplace";
 
 const EditPanel = (props) => {
   const { scope } = globalStore();
@@ -386,18 +387,21 @@ const EditPanel = (props) => {
           mergeOps={mergeForwardProps}
         />
       )}
-      {scope.isProject() && (
-        <CommitmentTable
-          serviceType={serviceType}
-          currentCategory={currentCategory}
-          currentResource={currentResource}
-          resource={currentResource}
-          currentTab={currentTab}
-          commitmentData={commitments}
-          mergeOps={mergeForwardProps}
-          scope={scope}
-        />
-      )}
+      {scope.isProject() &&
+        (currentTab !== CustomZones.MARKETPLACE ? (
+          <CommitmentTable
+            serviceType={serviceType}
+            currentCategory={currentCategory}
+            currentResource={currentResource}
+            resource={currentResource}
+            currentTab={currentTab}
+            commitmentData={commitments}
+            mergeOps={mergeForwardProps}
+            scope={scope}
+          />
+        ) : (
+          <Marketplace />
+        ))}
       {scope.isDomain() && (
         <ProjectManager
           serviceType={serviceType}

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -85,7 +85,7 @@ const EditPanel = (props) => {
   const { setRefetchCommitmentAPI } = createCommitmentStoreActions();
   const { setCommitmentIsLoading } = createCommitmentStoreActions();
   const conversionResults = useGetConversions({ serviceType, resourceName });
-  const [currentAZ, setCurrentAZ] = React.useState(currentResource.per_az[0].name);
+  const [currentTab, setCurrentTab] = React.useState(currentResource.per_az[0].name);
   const [projectsAreSortable, setProjectsAreSortable] = React.useState(false);
   // Merge Commitments
   const [commitmentsToMerge, setCommitmentsToMerge] = React.useState([]);
@@ -366,11 +366,10 @@ const EditPanel = (props) => {
         project={currentProject}
         resource={currentResource}
         serviceType={serviceType}
-        currentAZ={currentAZ}
         isPanelView={true}
         subRoute={subRoute}
         setIsMerging={setIsMerging}
-        setCurrentAZ={setCurrentAZ}
+        setCurrentTab={setCurrentTab}
         tracksQuota={tracksQuota}
       />
       <div className={"sticky top-0 z-[100] bg-juno-grey-light-1 h-8"}>
@@ -380,11 +379,10 @@ const EditPanel = (props) => {
       </div>
       {!subRoute && (
         <AvailabilityZoneNav
-          az={currentResource.per_az}
           resource={currentResource}
-          currentAZ={currentAZ}
+          currentTab={currentTab}
+          setCurrentTab={setCurrentTab}
           scope={scope}
-          setCurrentAZ={setCurrentAZ}
           mergeOps={mergeForwardProps}
         />
       )}
@@ -394,7 +392,7 @@ const EditPanel = (props) => {
           currentCategory={currentCategory}
           currentResource={currentResource}
           resource={currentResource}
-          currentAZ={currentAZ}
+          currentTab={currentTab}
           commitmentData={commitments}
           mergeOps={mergeForwardProps}
           scope={scope}
@@ -405,7 +403,7 @@ const EditPanel = (props) => {
           serviceType={serviceType}
           currentCategory={currentCategory}
           currentResource={currentResource}
-          currentAZ={currentAZ}
+          currentTab={currentTab}
           subRoute={subRoute}
           sortProjectProps={sortProjectProps}
           mergeOps={mergeForwardProps}
@@ -416,7 +414,7 @@ const EditPanel = (props) => {
           serviceType={serviceType}
           currentCategory={currentCategory}
           currentResource={currentResource}
-          currentAZ={currentAZ}
+          currentTab={currentTab}
           subRoute={subRoute}
           sortProjectProps={sortProjectProps}
           mergeOps={mergeForwardProps}
@@ -425,7 +423,7 @@ const EditPanel = (props) => {
       {isSubmitting && canConfirm != null && (
         <CommitmentModal
           action={postCommitment}
-          az={currentAZ}
+          currentTab={currentTab}
           canConfirm={canConfirm}
           commitment={newCommitment}
           minConfirmDate={minConfirmDate}
@@ -487,7 +485,7 @@ const EditPanel = (props) => {
       {deleteCommitment && (
         <DeleteModal
           action={deleteCommitmentAPI}
-          az={currentAZ}
+          currentTab={currentTab}
           title="Delete Commitment"
           subText="Delete"
           commitment={deleteCommitment}

--- a/src/components/panel/EditPanel.test.js
+++ b/src/components/panel/EditPanel.test.js
@@ -32,6 +32,19 @@ import StoreProvider, {
 import { CustomZones } from "../../lib/constants";
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
+
+queryClient.setQueryDefaults(["domains"], {
+  queryFn: () => {
+    return [];
+  },
+});
+
+queryClient.setQueryDefaults(["commitmentData"], {
+  queryFn: () => {
+    return [];
+  },
+});
+
 queryClient.setQueryDefaults(["getConversions"], {
   queryFn: () => {
     return;

--- a/src/components/panel/EditPanel.test.js
+++ b/src/components/panel/EditPanel.test.js
@@ -29,6 +29,7 @@ import StoreProvider, {
   createCommitmentStore,
   createCommitmentStoreActions,
 } from "../StoreProvider";
+import { CustomZones } from "../../lib/constants";
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { retry: 0 } } });
 queryClient.setQueryDefaults(["getConversions"], {
@@ -80,6 +81,20 @@ queryClient.setQueryDefaults(["projectsInDomain"], {
   },
 });
 
+queryClient.setQueryDefaults(["publicCommitments"], {
+  queryFn: ({}) => {
+    return {
+      commitments: [
+        {
+          id: "1",
+          amount: 10,
+          name: "commitment1",
+        },
+      ],
+    };
+  },
+});
+
 describe("EditPanel tests", () => {
   test("AZ selection state", async () => {
     const scope = new Scope({ projectID: "123", domainID: "456" });
@@ -120,6 +135,12 @@ describe("EditPanel tests", () => {
 
     const selectedAZ = screen.getByTestId("tab/az1");
     expect(selectedAZ).toHaveAttribute("aria-selected", "true");
+
+    // The Marketplace tab should be available, with an available item.
+    expect(screen.getByText(CustomZones.MARKETPLACE)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByTestId("MarketplaceInfoCount:1")).toBeInTheDocument();
+    });
   });
 
   test("Add commitment", async () => {

--- a/src/components/panel/PanelManager.js
+++ b/src/components/panel/PanelManager.js
@@ -78,6 +78,7 @@ const PanelManager = (props) => {
   //Durations get checked to avoid route call to uneditable resource.
   return (
     <Panel
+      className="bg-theme-background-lvl-0"
       size="large"
       opened={isEditing}
       onClose={() => {

--- a/src/components/project/ProjectManager.js
+++ b/src/components/project/ProjectManager.js
@@ -22,7 +22,7 @@ import { globalStoreActions, domainStoreActions, domainStore } from "../StorePro
 import { LoadingIndicator } from "@cloudoperators/juno-ui-components";
 
 const ProjectManager = (props) => {
-  const { serviceType, currentCategory, currentResource, currentAZ, subRoute, sortProjectProps, mergeOps } = props;
+  const { serviceType, currentCategory, currentResource, currentTab, subRoute, sortProjectProps, mergeOps } = props;
   const { enableSortActivities } = sortProjectProps;
   const resourceName = currentResource.name;
   const { refetchProjectAPI } = projectStore();
@@ -68,7 +68,7 @@ const ProjectManager = (props) => {
       serviceType={serviceType}
       currentCategory={currentCategory}
       currentResource={currentResource}
-      currentAZ={currentAZ}
+      currentTab={currentTab}
       projects={projects}
       subRoute={subRoute}
       sortProjectProps={sortProjectProps}

--- a/src/components/project/ProjectTable.js
+++ b/src/components/project/ProjectTable.js
@@ -82,7 +82,7 @@ const filterOpts = Object.freeze({
 
 // Display the project details in DomainView
 const ProjectTable = (props) => {
-  const { serviceType, currentResource, currentCategory, currentAZ, projects, subRoute, sortProjectProps, mergeOps } =
+  const { serviceType, currentResource, currentCategory, currentTab, projects, subRoute, sortProjectProps, mergeOps } =
     props;
   const resourceTracksQuota = tracksQuota(currentResource);
   const { scope } = globalStore();
@@ -135,7 +135,7 @@ const ProjectTable = (props) => {
 
     projects.forEach((project) => {
       project.categories[currentCategory].resources[0].per_az.forEach((az) => {
-        if (az.name !== currentAZ) return;
+        if (az.name !== currentTab) return;
         const matchingLabels = Object.values(labelTypes).filter((type) => matchAZLabel(az, type));
         if (matchingLabels.length > 0) {
           matchingLabels.forEach((label) => {
@@ -150,7 +150,7 @@ const ProjectTable = (props) => {
     });
 
     return { availableLabels: Array.from(uniqueLabels), projectsPerLabel: matchingProjects };
-  }, [currentAZ]);
+  }, [currentTab]);
 
   function getProjectsToFilter() {
     const projectsToFilter =
@@ -182,7 +182,7 @@ const ProjectTable = (props) => {
   }
   React.useEffect(() => {
     filterProjectsPerNameOrLabel();
-  }, [projects, currentAZ]);
+  }, [projects, currentTab]);
 
   function handleCommitmentTransfer(project) {
     setTransferProject(project);
@@ -271,7 +271,7 @@ const ProjectTable = (props) => {
             const resource = getCurrentResource(resources, currentResource.name);
             const showCommitments = project.metadata.id === selectedProject.id && selectedProject.showCommitments;
             const az = resource.per_az.find((az) => {
-              return az.name === currentAZ;
+              return az.name === currentTab;
             });
             return !subRoute ? (
               <ProjectTableDetails
@@ -286,7 +286,7 @@ const ProjectTable = (props) => {
                 resource={resource}
                 tracksQuota={resourceTracksQuota}
                 az={az}
-                currentAZ={currentAZ}
+                currentTab={currentTab}
                 colSpan={colSpan}
                 mergeOps={mergeOps}
               />

--- a/src/components/project/ProjectTable.js
+++ b/src/components/project/ProjectTable.js
@@ -33,6 +33,7 @@ import {
   SelectOption,
 } from "@cloudoperators/juno-ui-components";
 import ProjectQuotaDetails from "./ProjectQuotaDetails";
+import { TransferStatus } from "../../lib/constants";
 import { labelTypes, matchAZLabel } from "../shared/LimesBadges";
 
 const projectTableHeadCells = [
@@ -88,6 +89,7 @@ const ProjectTable = (props) => {
   const { scope } = globalStore();
   const [selectedProject, setSelectedProject] = React.useState({ id: "", showCommitments: false });
   const { setSortedProjects } = domainStoreActions();
+  const { setTransferFromAndToProject } = createCommitmentStoreActions();
   const { setTransferProject } = createCommitmentStoreActions();
   const { setCurrentProject } = createCommitmentStoreActions();
   const { setToast } = createCommitmentStoreActions();
@@ -186,6 +188,7 @@ const ProjectTable = (props) => {
 
   function handleCommitmentTransfer(project) {
     setTransferProject(project);
+    setTransferFromAndToProject(TransferStatus.START);
   }
 
   return projects ? (

--- a/src/components/project/ProjectTable.test.js
+++ b/src/components/project/ProjectTable.test.js
@@ -33,7 +33,7 @@ const mockProps = {
   serviceType: "Service1",
   currentResource: { name: "Resource1" },
   currentCategory: "Category1",
-  currentAZ: "AZ1",
+  currentTab: "AZ1",
   projects: [],
   sortProjectProps: { projectsAreSortable: true, setProjectsAreSortable: jest.fn() },
   mergeOps: {},
@@ -88,7 +88,7 @@ describe("ProjectTable", () => {
             resources: [
               {
                 name: mockProps.currentResource.name,
-                per_az: [{ name: mockProps.currentAZ, pending_commitments: { "1 year": 10 } }],
+                per_az: [{ name: mockProps.currentTab, pending_commitments: { "1 year": 10 } }],
               },
             ],
           },
@@ -98,7 +98,7 @@ describe("ProjectTable", () => {
         metadata: { id: "2", name: "Project2", fullName: "domain2/Project2" },
         categories: {
           [mockProps.currentCategory]: {
-            resources: [{ name: mockProps.currentResource.name, per_az: [{ name: mockProps.currentAZ }] }],
+            resources: [{ name: mockProps.currentResource.name, per_az: [{ name: mockProps.currentTab }] }],
           },
         },
       },

--- a/src/components/project/ProjectTableDetails.js
+++ b/src/components/project/ProjectTableDetails.js
@@ -42,7 +42,7 @@ const ProjectTableDetails = (props) => {
     project,
     resource,
     az,
-    currentAZ,
+    currentTab,
     colSpan,
     mergeOps,
   } = props;
@@ -204,7 +204,7 @@ const ProjectTableDetails = (props) => {
                 currentCategory={currentCategory}
                 currentResource={resource}
                 resource={resource}
-                currentAZ={currentAZ}
+                currentTab={currentTab}
                 commitmentData={commitments}
                 mergeOps={mergeOps}
               />

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -16,11 +16,11 @@
 
 import React from "react";
 import ResourceBar, { getAppliedBarColors } from "./ResourceBar";
-import { Unit } from "../../lib/unit";
-import useResourceBarValues, { ResourceBarType } from "../../hooks/useResourceBarValues";
-import { Stack } from "@cloudoperators/juno-ui-components/index";
-import { getBarLabel, getEmptyBarLabel, hasAnyBarValues } from "./resourceBarUtils";
 import ResourceInfo from "./ResourceInfo";
+import { Stack } from "@cloudoperators/juno-ui-components/index";
+import { Unit } from "../../lib/unit";
+import { getBarLabel, getBasicResourceInfo, getEmptyBarLabel, hasAnyBarValues } from "./resourceBarUtils";
+import useResourceBarValues, { ResourceBarType } from "../../hooks/useResourceBarValues";
 
 const barConainer = `
   min-w-full 
@@ -33,6 +33,7 @@ const ResourceBarBuilder = (props) => {
   const { scope, categoryName, resource, az, unit: unitName, barType, isEditableResource } = { ...props };
   const { showToolTip = false, displayResourceInfo = false } = { ...props };
   const unit = new Unit(unitName || "");
+  const isBasicResource = getBasicResourceInfo(resource);
   const isGranular = barType === ResourceBarType.granular;
   const currentResource = isGranular ? az : resource;
   const { leftBar, rightBar } = useResourceBarValues(currentResource, barType);
@@ -60,7 +61,7 @@ const ResourceBarBuilder = (props) => {
     let toolTipContent;
     if (bar === rightBar) {
       barBackGround = getAppliedBarColors(bar, paygStyle);
-      toolTipContent = "Pay as you go";
+      isBasicResource ? (toolTipContent = "Usage") : (toolTipContent = "Pay as you go");
     } else {
       barBackGround = getAppliedBarColors(bar);
       toolTipContent = "Committed usage";

--- a/src/components/resourceBar/ResourceInfo.js
+++ b/src/components/resourceBar/ResourceInfo.js
@@ -16,7 +16,7 @@
 
 import React from "react";
 import { IntroBox } from "@cloudoperators/juno-ui-components/index";
-import { hasAnyBarValues } from "./resourceBarUtils";
+import { getBasicResourceInfo, hasAnyBarValues } from "./resourceBarUtils";
 import { locateBaseQuotaAZ } from "../../lib/utils";
 import { CustomZones } from "../../lib/constants";
 import { Unit } from "../../lib/unit";
@@ -37,7 +37,7 @@ const ResourceInfo = (props) => {
   const { leftBar, rightBar } = { ...props };
   const hasLeftBar = hasAnyBarValues(leftBar);
   const hasRightBar = hasAnyBarValues(rightBar);
-
+  const isBasicResource = getBasicResourceInfo(resource);
   const resourceInfos = React.useMemo(() => {
     const infos = [];
 
@@ -121,7 +121,11 @@ const ResourceInfo = (props) => {
       return PAYGLabels.UNAVAILABLE;
     }
     if (rightBar.utilized > 0) {
-      return PAYGLabels.AVAILABLE(unit.format(rightBar.utilized));
+      if (isBasicResource) {
+        return PAYGLabels.AVAILABLE_BASIC(unit.format(rightBar.utilized));
+      } else {
+        return PAYGLabels.AVAILABLE(unit.format(rightBar.utilized));
+      }
     }
     if (rightBar.utilized < 0) {
       return PAYGLabels.INVALID;

--- a/src/components/resourceBar/ResourceInfo.test.js
+++ b/src/components/resourceBar/ResourceInfo.test.js
@@ -105,8 +105,9 @@ describe("Resource info tests", () => {
   });
 
   test("renders PAYG info when rightBar has values", () => {
+    const resourceInfo = { commitment_config: { durations: ["1 month"] }, commitment_sum: 0 };
     const props = {
-      resource: {},
+      resource: resourceInfo,
       az: { name: "AZ1" },
       unit: new Unit("MiB"),
       leftBar: resourceBar,
@@ -114,24 +115,30 @@ describe("Resource info tests", () => {
     };
 
     const { rerender } = render(<ResourceInfo {...props} />);
-    expect(screen.getByTestId(/PAYG.AVAILABLE/i)).toBeInTheDocument();
+    expect(screen.getByTestId("PAYG.AVAILABLE")).toBeInTheDocument();
     expect(screen.getByText("1 GiB")).toBeInTheDocument();
+    // resources that are not committable and do not contain remaining committments should print a basic "usage" info.
+    props.resource = {};
+    rerender(<ResourceInfo {...props} />);
+    expect(screen.getByTestId("USAGE_BASIC")).toBeInTheDocument();
+    props.resource = resourceInfo;
 
+    // invalid value distribution.
     props.rightBar = { utilized: -1024, available: 1024 };
     rerender(<ResourceInfo {...props} />);
-    expect(screen.getByTestId(/PAYG.INVALID/i)).toBeInTheDocument();
+    expect(screen.getByTestId("PAYG.INVALID")).toBeInTheDocument();
 
     // resources without pay as you go usage should not display info.
     props.rightBar = resourceBar;
     rerender(<ResourceInfo {...props} />);
-    expect(screen.queryByTestId(/PAYG.AVAILABLE/i)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(/PAYG.INVALID/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("PAYG.AVAILABLE")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("PAYG.INVALID")).not.toBeInTheDocument();
 
     // resoruces with payg usage 0 should not display info.
     props.rightBar = { utilized: 0, available: 1 };
     rerender(<ResourceInfo {...props} />);
-    expect(screen.getByTestId(/PAYG.UNAVAILABLE/i)).toBeInTheDocument();
-    expect(screen.queryByTestId(/PAYG.AVAILABLE/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("PAYG.UNAVAILABLE")).toBeInTheDocument();
+    expect(screen.queryByTestId("PAYG.AVAILABLE")).not.toBeInTheDocument();
   });
 
   test("renders base quota info", () => {

--- a/src/components/resourceBar/resourceBarUtils.js
+++ b/src/components/resourceBar/resourceBarUtils.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { locateBaseQuotaAZ } from "../../lib/utils";
+import { locateBaseQuotaAZ, getResourceDurations } from "../../lib/utils";
 
 export function getBarLabel(resource) {
   if (resource.commitmentSum > 0) {
@@ -40,4 +40,9 @@ export function getEmptyBarLabel(resource) {
 
 export function hasAnyBarValues(barValues) {
   return barValues.utilized > 0 || barValues.available > 0;
+}
+
+export function getBasicResourceInfo(resource) {
+  const commitmentSum = resource?.commitmentSum || 0;
+  return getResourceDurations(resource).length == 0 && commitmentSum == 0;
 }

--- a/src/components/resourceBar/resourceInfoLabels.js
+++ b/src/components/resourceBar/resourceInfoLabels.js
@@ -73,6 +73,11 @@ export const PAYGLabels = {
       Pay-As-You-Go usage: <strong>{amount}</strong>.
     </span>
   ),
+  AVAILABLE_BASIC: (amount) => (
+    <span data-testid="USAGE_BASIC">
+      Usage: <strong>{amount}</strong>.
+    </span>
+  ),
   UNAVAILABLE: <span data-testid="PAYG.UNAVAILABLE">No Pay-As-You-Go usage present.</span>,
   INVALID: (
     <span data-testid="PAYG.INVALID">Invalid Pay-As-You-Go usage detected. Please create a support ticket.</span>

--- a/src/hooks/useResetCommitment.js
+++ b/src/hooks/useResetCommitment.js
@@ -38,7 +38,6 @@ const useResetCommitment = () => {
   function resetURLChangeState() {
     setIsCommitting(false);
     setCommitment(initialCommitmentObject);
-    setTransferredCommitment(initialCommitmentObject);
     setDeleteCommitment(null);
     setConversionCommitment(null);
     setUpdateDurationCommitment(null);
@@ -49,6 +48,7 @@ const useResetCommitment = () => {
   // Handle commitment transfer mode cancellation.
   function resetCommitmentTransfer() {
     setCommitment(initialCommitmentObject);
+    setTransferredCommitment(initialCommitmentObject);
     setTransferCommitment(false);
     setIsTransferring(false);
     setTransferFromAndToProject(null);

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -275,6 +275,17 @@ const useQueryClientFn = () => {
   // ClusterView Endpoints
   React.useEffect(() => {
     if (!queryClient || !endpoint || !token) return;
+    queryClient.setQueryDefaults(["publicCommitments"], {
+      queryFn: async ({ queryKey }) => {
+        const [, { service, resource }] = queryKey;
+        const url = `${endpoint}/v1/public-commitments?service=${service}&resource=${resource}`;
+        const response = await fetch(url, {
+          method: "GET",
+          headers: { Accept: "application/json", "X-Limes-V2-API-Preview": "per-az", "X-Auth-Token": token },
+        });
+        return responseHandler(response);
+      },
+    });
     queryClient.setQueryDefaults(["clusterData"], {
       queryFn: async ({ queryKey }) => {
         const isDetail = queryKey[1];

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -34,6 +34,7 @@ export const initialCommitmentObject = {
 export const CustomZones = Object.freeze({
   ANY: "any",
   UNKNOWN: "unknown",
+  MARKETPLACE: "Marketplace"
 });
 
 // Transfer commitment on project level

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -34,7 +34,7 @@ export const initialCommitmentObject = {
 export const CustomZones = Object.freeze({
   ANY: "any",
   UNKNOWN: "unknown",
-  MARKETPLACE: "Marketplace"
+  MARKETPLACE: "Marketplace",
 });
 
 // Transfer commitment on project level
@@ -46,6 +46,11 @@ export const TransferStatus = Object.freeze({
   START: 1,
   VIEW: 2,
   RECEIVE: 3,
+});
+export const TransferType = Object.freeze({
+  UNLISTED: "unlisted",
+  PUBLIC: "public",
+  NONE: "",
 });
 
 // Distinguish EditPanels with different purposes. F.e.: Max-Quota Editing or Commitment creation.

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -42,6 +42,7 @@ export const CustomZones = Object.freeze({
 // 1. A view where a transfer can be initiated
 // 2. A view to copy the transfer token at the source project
 // 3. A view to enter the transfer token at the target project
+// 4. A view to reset the current transfer state
 export const TransferStatus = Object.freeze({
   START: 1,
   VIEW: 2,

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -46,6 +46,7 @@ export const TransferStatus = Object.freeze({
   START: 1,
   VIEW: 2,
   RECEIVE: 3,
+  CANCEL: 4,
 });
 export const TransferType = Object.freeze({
   UNLISTED: "unlisted",

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -134,7 +134,7 @@ const limesStore = (set, get) => ({
     //requery API after commit POST to get fresh commitment data for the resource bars.
     projectData: null,
     refetchProjectAPI: false,
-    commitments: null,
+    commitments: [],
 
     actions: {
       setProjectData: (projectData) =>


### PR DESCRIPTION
Resources that are not committable and do not contain any committments would display `PAYG usage` information. Instead they should report `Usage` information, because the existing usage is not payg.

This PR is based on https://github.com/sapcc/LimesUI/pull/135
and needs to be rebased.