### PR TITLE
fix visibility of the forbid autogrowth setting

### DIFF
--- a/.changeset/proud-donkeys-roll.md
+++ b/.changeset/proud-donkeys-roll.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+Remove forbid autogrowth setting for resources that are not committable and don't have remaining commitments"

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -170,7 +170,7 @@ const Resource = (props) => {
           {isAZUnaware(props.resource.per_az) && (
             <ProjectBadges az={props.resource.per_az[0]} unit={unitName} displayValues={true} />
           )}
-          {scope.isProject() && <ForbidAutogrowth {...forbidAutogrowthForwardProps} />}
+          {scope.isProject() && editableResource && <ForbidAutogrowth {...forbidAutogrowthForwardProps} />}
         </Stack>
       )}
       <ResourceBarBuilder

--- a/src/components/mainView/subComponents/ForbidAutogrowth.js
+++ b/src/components/mainView/subComponents/ForbidAutogrowth.js
@@ -107,7 +107,7 @@ const ForbidAutogrowth = (props) => {
           {autogrowthForbidden && (
             <div className="text-sm mt-2">
               Disabling will limit your available quota to either your existing commitments or your current usage,
-              whichever value is greater.
+              whichever value is greater. Changes to this setting typically take around 15 minutes to take effect.
             </div>
           )}
         </p>

--- a/src/components/mainView/subComponents/ForbidAutogrowth.js
+++ b/src/components/mainView/subComponents/ForbidAutogrowth.js
@@ -104,6 +104,12 @@ const ForbidAutogrowth = (props) => {
         )}
         <p data-testid="forbidAutogrowthConfirmText">
           Do you want to <strong>{autogrowthForbidden ? "disable" : "enable"}</strong> Pay-As-You-Go?
+          {autogrowthForbidden && (
+            <div className="text-sm mt-2">
+              Disabling will limit your available quota to either your existing commitments or your current usage,
+              whichever value is greater.
+            </div>
+          )}
         </p>
       </Modal>
     </>


### PR DESCRIPTION
On project level only resources which are committable or that have remaining commitments should allow this setting