### PR TITLE
fix: Add attribute to dependency list

### DIFF
--- a/src/components/project/ProjectTableDetails.js
+++ b/src/components/project/ProjectTableDetails.js
@@ -85,7 +85,7 @@ const ProjectTableDetails = (props) => {
     if (!refetchCommitmentAPI || !showCommitments) return;
     setRefetchCommitmentAPI(false);
     commitQueryResult.refetch();
-  }, [refetchCommitmentAPI]);
+  }, [refetchCommitmentAPI, showCommitments]);
 
   // only display the move commitment button on projects with a commitment on them.
   React.useEffect(() => {


### PR DESCRIPTION
If a marketplace commitment is taken, the state to refetch the commitment API is set to `true`,  however, after a project is selected in order to trigger the commitments marketplace reset, it is not requeried.
The issue is the missing attribute within the requery useEffect and will now be added to the dependency list.