### PR TITLE
feat: add endpoint_services quota display support

### DIFF
--- a/.changeset/endpoint-services-quota.md
+++ b/.changeset/endpoint-services-quota.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": minor
+---
+
+Add endpoint_services quota display support for endpoints and services resources

--- a/src/quota/Usage.js
+++ b/src/quota/Usage.js
@@ -90,6 +90,12 @@ const QuotaUsage = (props) => {
           resources: ["capacity"],
         });
         break;
+      case "endpoint_services":
+        setService({
+          type: "endpoint-services",
+          resources: ["endpoints", "services"],
+        });
+        break;
       default:
         setDisplayLabel(null);
         break;


### PR DESCRIPTION
Add case for endpoint_services in quota Usage component to display
remaining quota for endpoints and services resources.
