### PR TITLE
add non standard unit support

### DIFF
--- a/.changeset/happy-plants-throw.md
+++ b/.changeset/happy-plants-throw.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": minor
+---
+
+Add non standard unit support

--- a/src/components/commitment/CommitmentTableDetails.js
+++ b/src/components/commitment/CommitmentTableDetails.js
@@ -53,7 +53,7 @@ const CommitmentTableDetails = (props) => {
   const [invalidInput, setInvalidInput] = React.useState(false);
   const unit = new Unit(unitName);
   const initialParsedAmount = unit.format(amount, { ascii: true });
-  const inputRef = React.useRef(initialParsedAmount);
+  const [commitmentInput, setCommitmentInput] = React.useState(initialParsedAmount);
   const durationLabel = React.useRef("");
 
   function stopEditing() {
@@ -67,7 +67,7 @@ const CommitmentTableDetails = (props) => {
   function handleInput(e) {
     setInvalidInput(false);
     setToast(null);
-    inputRef.current = e.target.value;
+    setCommitmentInput(e.target.value);
   }
 
   function handleSelect(value) {
@@ -79,7 +79,7 @@ const CommitmentTableDetails = (props) => {
   }
 
   function handleSave() {
-    const parsedInput = unit.parse(inputRef.current);
+    const parsedInput = unit.parse(commitmentInput);
     if (parsedInput.error) {
       setInvalidInput(true);
       setToast(parsedInput.error);
@@ -128,20 +128,25 @@ const CommitmentTableDetails = (props) => {
 
   return (
     <DataGridRow>
-      <DataGridCell>
+      <DataGridCell className="justify-start">
         {isAddingCommitment ? (
-          <TextInput
-            data-cy="commitmentInput"
-            value={inputRef.current}
-            invalid={invalidInput}
-            autoFocus={true}
-            onChange={(e) => handleInput(e)}
-          />
+          <>
+            <TextInput
+              data-cy="commitmentInput"
+              value={commitmentInput}
+              invalid={invalidInput}
+              autoFocus={true}
+              onChange={(e) => handleInput(e)}
+            />
+            <div className="mt-1 whitespace-nowrap text-xs text-sap-grey-4">
+              {unit.isSpecialUnit && `commitment amount: ${unit.specialUnitConversion(commitmentInput) || 0}`}
+            </div>
+          </>
         ) : (
           valueWithUnit(amount, unit)
         )}
       </DataGridCell>
-      <DataGridCell>
+      <DataGridCell className="justify-start">
         {isAddingCommitment ? (
           <Select
             data-cy="commitmentSelect"
@@ -162,10 +167,10 @@ const CommitmentTableDetails = (props) => {
           duration
         )}
       </DataGridCell>
-      <DataGridCell className="items-start">
+      <DataGridCell className="justify-start">
         <ToolTipWrapper trigger={formatTimeISO8160(startDate)} content={formatTime(startDate, "YYYY-MM-DD HH:mm A")} />
       </DataGridCell>
-      <DataGridCell className="items-start">
+      <DataGridCell className="justify-start">
         <ToolTipWrapper
           trigger={formatTimeISO8160(confirmed_at) || (!isAddingCommitment ? "Unconfirmed" : "")}
           content={
@@ -182,16 +187,16 @@ const CommitmentTableDetails = (props) => {
           }
         />
       </DataGridCell>
-      <DataGridCell className="items-start">
+      <DataGridCell className="justify-start">
         <ToolTipWrapper
           trigger={formatTimeISO8160(expires_at)}
           content={formatTime(expires_at, "YYYY-MM-DD HH:mm A")}
         />
       </DataGridCell>
-      <DataGridCell className="items-start truncate">
+      <DataGridCell className="justify-start truncate">
         <ToolTipWrapper trigger={parseRequesterName(creator_name)} content={creator_name} />
       </DataGridCell>
-      <DataGridCell>
+      <DataGridCell className="justify-start">
         {isAddingCommitment ? (
           <Stack gap="2">
             <Button

--- a/src/components/commitment/CommitmentTableDetails.js
+++ b/src/components/commitment/CommitmentTableDetails.js
@@ -2,13 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
-import { DataGridRow, DataGridCell, Button, Select, TextInput, Stack } from "@cloudoperators/juno-ui-components";
+import { DataGridRow, DataGridCell, Button, Select, Stack } from "@cloudoperators/juno-ui-components";
 import Actions from "./Operations/Actions";
-import { valueWithUnit, Unit } from "../../lib/unit";
+import { createUnit, valueWithUnit } from "../../lib/unit";
 import { formatTime, formatTimeISO8160 } from "../../lib/utils";
 import { createCommitmentStoreActions, useCreateCommitmentStore } from "../StoreProvider";
 import CommitmentDurationInputLabel from "./CommitmentDurationInputLabel";
 import ToolTipWrapper from "../shared/ToolTipWrapper";
+import InputWithUnit from "../shared/InputWithUnit";
 import { initialCommitmentObject } from "../../lib/constants";
 import { COMMITMENTID } from "../../lib/constants";
 import useResetCommitment from "../../hooks/useResetCommitment";
@@ -51,9 +52,9 @@ const CommitmentTableDetails = (props) => {
   const { setToast } = createCommitmentStoreActions();
   const [invalidDuration, setInValidDuration] = React.useState(false);
   const [invalidInput, setInvalidInput] = React.useState(false);
-  const unit = new Unit(unitName);
-  const initialParsedAmount = unit.format(amount, { ascii: true });
-  const [commitmentInput, setCommitmentInput] = React.useState(initialParsedAmount);
+  const unit = createUnit(unitName);
+  const initialParsedAmount = unit.formatForInput(amount, { ascii: true });
+  const commitmentInputRef = React.useRef(initialParsedAmount);
   const durationLabel = React.useRef("");
 
   function stopEditing() {
@@ -64,10 +65,9 @@ const CommitmentTableDetails = (props) => {
     setToast(null);
   }
 
-  function handleInput(e) {
+  function handleInput() {
     setInvalidInput(false);
     setToast(null);
-    setCommitmentInput(e.target.value);
   }
 
   function handleSelect(value) {
@@ -79,7 +79,7 @@ const CommitmentTableDetails = (props) => {
   }
 
   function handleSave() {
-    const parsedInput = unit.parse(commitmentInput);
+    const parsedInput = unit.parse(commitmentInputRef.current);
     if (parsedInput.error) {
       setInvalidInput(true);
       setToast(parsedInput.error);
@@ -130,18 +130,12 @@ const CommitmentTableDetails = (props) => {
     <DataGridRow>
       <DataGridCell className="justify-start">
         {isAddingCommitment ? (
-          <>
-            <TextInput
-              data-cy="commitmentInput"
-              value={commitmentInput}
-              invalid={invalidInput}
-              autoFocus={true}
-              onChange={(e) => handleInput(e)}
-            />
-            <div className="mt-1 whitespace-nowrap text-xs text-sap-grey-4">
-              {unit.isSpecialUnit && `commitment amount: ${unit.specialUnitConversion(commitmentInput) || 0}`}
-            </div>
-          </>
+          <InputWithUnit
+            inputRef={commitmentInputRef}
+            invalid={invalidInput}
+            onChange={() => handleInput()}
+            unit={unit}
+          />
         ) : (
           valueWithUnit(amount, unit)
         )}

--- a/src/components/commitment/CommitmentTableDetails.test.js
+++ b/src/components/commitment/CommitmentTableDetails.test.js
@@ -11,22 +11,7 @@ import StoreProvider, { useCreateCommitmentStore, createCommitmentStoreActions }
 const durations = ["1 year", "2 years", "3 years"];
 const commitment = { ...initialCommitmentObject };
 
-const selectErrors = console.error.bind(console);
-
 describe("CheckCommitedState", () => {
-  beforeAll(() => {
-    // Junos select requires one string. Because we format the text of our subtexts, a proptype error will be fired.
-    // The contents will still be processed by the library, which is why the prop type error gets disabled here.
-    console.error = (errormessage) => {
-      const suppressedError = errormessage.toString();
-      const match = new RegExp("Warning: Failed .+ type").exec(suppressedError)[0];
-      !match && selectErrors(errormessage);
-    };
-  });
-  afterAll(() => {
-    console.error = selectErrors;
-  });
-
   test("Check Commited display", async () => {
     const confirmedCommitment = { ...commitment };
     confirmedCommitment.amount = 1003;
@@ -52,16 +37,110 @@ describe("CheckCommitedState", () => {
     const commitedField = screen.getByDisplayValue(confirmedCommitment.amount);
     expect(commitedField).toBeInTheDocument();
   });
+
+  test("Check Commited display with non-standard unit", async () => {
+    const confirmedCommitment = { ...commitment };
+    confirmedCommitment.id = "1";
+    confirmedCommitment.amount = 2;
+    confirmedCommitment.requested_at = 1696636800;
+    confirmedCommitment.confirmed_at = 1696636800;
+    confirmedCommitment.unit = "128 GiB";
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <CommitmentTableDetails commitment={confirmedCommitment} durations={durations} />
+          {children}
+        </StoreProvider>
+      </PortalProvider>
+    );
+    await waitFor(() => {
+      renderHook(
+        () => ({
+          commitmentStore: useCreateCommitmentStore(),
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+    // unit "128 GiB" and amount 2, the display should show "256 GiB"
+    const commitedField = screen.getByText("256 GiB");
+    expect(commitedField).toBeInTheDocument();
+  });
+
+  test("Create commitment with unit", async () => {
+    const commitmentWithUnit = { ...commitment, amount: 0, unit: "MiB" };
+    const value = "1024 MiB";
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <CommitmentTableDetails commitment={commitmentWithUnit} durations={durations} />
+          {children}
+        </StoreProvider>
+      </PortalProvider>
+    );
+    let store = await waitFor(() => {
+      return renderHook(
+        () => ({
+          commitmentStore: useCreateCommitmentStore(),
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+
+    const input = screen.getByTestId("inputWithUnit");
+    fireEvent.change(input, { target: { value: value } });
+    expect(input.value).toEqual(value);
+    const year1 = screen.getByText(new RegExp(durations[0], "i"));
+    fireEvent.click(year1);
+    await waitFor(() => {
+      expect(year1.textContent).toEqual(durations[0]);
+    });
+    const save = screen.getByText(/save/i);
+    fireEvent.click(save);
+    expect(store.result.current.commitmentStore.commitment.amount).toEqual(1024);
+  });
+
+  test("Create commitment with non standard unit", async () => {
+    const commitmentWithUnit = { ...commitment, amount: 0, unit: "128 GiB" };
+    const value = "2";
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <CommitmentTableDetails commitment={commitmentWithUnit} durations={durations} />
+          {children}
+        </StoreProvider>
+      </PortalProvider>
+    );
+    let store = await waitFor(() => {
+      return renderHook(
+        () => ({
+          commitmentStore: useCreateCommitmentStore(),
+          commitmentStoreActions: createCommitmentStoreActions(),
+        }),
+        { wrapper }
+      );
+    });
+
+    const input = screen.getByTestId("inputWithUnit");
+    fireEvent.change(input, { target: { value: value } });
+    expect(input.value).toEqual(value);
+    const year1 = screen.getByText(new RegExp(durations[0], "i"));
+    fireEvent.click(year1);
+    await waitFor(() => {
+      expect(year1.textContent).toEqual(durations[0]);
+    });
+    const save = screen.getByText(/save/i);
+    fireEvent.click(save);
+    expect(store.result.current.commitmentStore.commitment.amount).toEqual(2);
+  });
 });
 
 describe("EditCommitments", () => {
   let store;
   beforeEach(async () => {
-    console.error = (errormessage) => {
-      const suppressedError = errormessage.toString();
-      const match = new RegExp("Warning: Failed .+ type").exec(suppressedError)[0];
-      !match && selectErrors(errormessage);
-    };
     const wrapper = ({ children }) => (
       <PortalProvider>
         <StoreProvider>
@@ -79,10 +158,6 @@ describe("EditCommitments", () => {
         { wrapper }
       );
     });
-  });
-
-  afterAll(() => {
-    console.error = selectErrors;
   });
 
   test("Check default InputValue", () => {

--- a/src/components/commitment/MarketplaceDetails.js
+++ b/src/components/commitment/MarketplaceDetails.js
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components/index";
-import { valueWithUnit, Unit } from "../../lib/unit";
+import { createUnit, valueWithUnit } from "../../lib/unit";
 import { formatTimeISO8160, formatTime } from "../../lib/utils";
 import ToolTipWrapper from "../shared/ToolTipWrapper";
 import MarketplaceModal from "./Modals/MarketplaceModal";
@@ -11,7 +11,7 @@ import MarketplaceActions from "./MarketplaceActions";
 
 const MarketplaceDetails = (props) => {
   const { project, commitment, transferCommitment } = props;
-  const unit = new Unit(commitment.unit);
+  const unit = createUnit(commitment?.unit);
   const [showModal, setShowModal] = React.useState(false);
 
   return (

--- a/src/components/commitment/Modals/CommitmentModal.js
+++ b/src/components/commitment/Modals/CommitmentModal.js
@@ -15,7 +15,7 @@ import BaseFooter from "./BaseComponents/BaseFooter";
 import CommitmentCalendar from "../CommitmentCalendar";
 import moment from "moment";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
-import { Unit, valueWithUnit } from "../../../lib/unit";
+import { createUnit, valueWithUnit } from "../../../lib/unit";
 import { formatTimeISO8160 } from "../../../lib/utils";
 
 const label = "font-semibold";
@@ -32,7 +32,7 @@ const CommitmentModal = (props) => {
     subText,
     title,
   } = { ...props };
-  const unit = new Unit(commitment.unit);
+  const unit = createUnit(commitment?.unit);
   const { data: publicCommitmentData } = publicCommitmentQuery;
   const publicCommitments = publicCommitmentData?.commitments || [];
   const hasApplicablePublicCommitments = publicCommitments.some((c) => c?.availability_zone === currentTab);

--- a/src/components/commitment/Modals/ConversionModal.js
+++ b/src/components/commitment/Modals/ConversionModal.js
@@ -17,7 +17,7 @@ import {
 import BaseFooter from "./BaseComponents/BaseFooter";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
 import { t } from "../../../lib/utils";
-import { Unit } from "../../../lib/unit";
+import { createUnit } from "../../../lib/unit";
 
 const label = "font-semibold";
 
@@ -31,9 +31,9 @@ const ConversionModal = (props) => {
   const { conversions } = data || { conversions: [] };
   const [invalidConversion, setInvalidConversion] = React.useState(false);
   const [currentConversion, setCurrentConversion] = React.useState(null);
-  const unit = new Unit(commitment.unit);
+  const unit = createUnit(commitment?.unit);
   // Needs to be an object. The same suggested conversion value on select of a different conversion type would not trigger a rerender.
-  const [conversion, setConversion] = React.useState({ amount: "" });
+  const [conversion, setConversion] = React.useState({ amount: 0 });
   const [targetAmount, setTargetAmount] = React.useState();
   const [insufficientAmount, setInsufficientAmount] = React.useState(false);
 
@@ -41,14 +41,13 @@ const ConversionModal = (props) => {
   React.useEffect(() => {
     if (!currentConversion) return;
     const amount = Math.floor(commitment.amount / currentConversion.from) * currentConversion.from;
-    const formattedAmount = unit.format(amount, { ascii: true });
     if (amount == 0) {
-      setConversion({ amount: formattedAmount });
+      setConversion({ amount: amount });
       setTargetAmount(null);
       setInsufficientAmount(true);
       return;
     }
-    setConversion({ amount: formattedAmount });
+    setConversion({ amount: amount });
   }, [currentConversion]);
 
   // set target amount based on desired conversion.
@@ -56,14 +55,14 @@ const ConversionModal = (props) => {
     if (!currentConversion || insufficientAmount) {
       return;
     }
-    const parsedAmount = unit.parse(conversion.amount);
-    const invalidConversion = parsedAmount % currentConversion.from != 0;
-    if (parsedAmount.error || parsedAmount > commitment.amount || parsedAmount <= 0 || invalidConversion) {
+    const amount = conversion.amount;
+    const invalidConversion = amount % currentConversion.from != 0;
+    if (amount > commitment.amount || amount <= 0 || invalidConversion) {
       setInvalidConversion(true);
       return;
     }
-    const targetAmount = (parsedAmount / currentConversion.from) * currentConversion.to;
-    setTargetAmount(unit.format(targetAmount, { ascii: true }));
+    const targetAmount = (amount / currentConversion.from) * currentConversion.to;
+    setTargetAmount(targetAmount);
   }, [conversion]);
 
   function onConversionInput(e) {
@@ -79,10 +78,9 @@ const ConversionModal = (props) => {
 
   function onConfirm() {
     if (!currentConversion) return;
-    const parsedInput = unit.parse(conversion.amount);
-    const parsedAmount = unit.parse(targetAmount);
+    const sourceAmount = conversion.amount;
     // defense in depth.
-    if (parsedInput.error || parsedInput > commitment.amount || parsedInput <= 0 || invalidConversion) {
+    if (sourceAmount > commitment.amount || sourceAmount <= 0 || invalidConversion) {
       setInvalidConversion(true);
       return;
     }
@@ -90,8 +88,8 @@ const ConversionModal = (props) => {
       commitment: {
         target_service: currentConversion.target_service,
         target_resource: currentConversion.target_resource,
-        source_amount: parsedInput,
-        target_amount: parsedAmount,
+        source_amount: parseInt(sourceAmount),
+        target_amount: targetAmount,
       },
     };
     onConvert(commitment, payload);
@@ -127,7 +125,7 @@ const ConversionModal = (props) => {
             </DataGridRow>
             <DataGridRow>
               <DataGridCell className={label}>Amount:</DataGridCell>
-              <DataGridCell>{commitment.amount}</DataGridCell>
+              <DataGridCell>{unit.format(commitment.amount)}</DataGridCell>
             </DataGridRow>
             <DataGridRow>
               <DataGridCell className={label}>Target:</DataGridCell>
@@ -173,7 +171,11 @@ const ConversionModal = (props) => {
                   autoFocus
                   value={conversion.amount}
                   errortext={invalidConversion && "Please enter a valid amount."}
-                  successtext={!invalidConversion && targetAmount && `target amount: ${targetAmount}`}
+                  successtext={
+                    !invalidConversion &&
+                    targetAmount &&
+                    `target amount: ${unit.format(targetAmount)} ${!unit.isStandardUnit ? `(${targetAmount} * ${unit.name})` : ""} `
+                  }
                   onChange={(e) => {
                     onConversionInput(e);
                   }}

--- a/src/components/commitment/Modals/ConversionModal.js
+++ b/src/components/commitment/Modals/ConversionModal.js
@@ -174,7 +174,7 @@ const ConversionModal = (props) => {
                   successtext={
                     !invalidConversion &&
                     targetAmount &&
-                    `target amount: ${unit.format(targetAmount)} ${!unit.isStandardUnit ? `(${targetAmount} * ${unit.name})` : ""} `
+                    `target amount: ${unit.format(targetAmount)} ${!unit.isStandardUnit ? `(${targetAmount} * ${unit.name})` : ""}`
                   }
                   onChange={(e) => {
                     onConversionInput(e);

--- a/src/components/commitment/Modals/ConversionModal.js
+++ b/src/components/commitment/Modals/ConversionModal.js
@@ -55,9 +55,9 @@ const ConversionModal = (props) => {
     if (!currentConversion || insufficientAmount) {
       return;
     }
-    const amount = conversion.amount;
-    const invalidConversion = amount % currentConversion.from != 0;
-    if (amount > commitment.amount || amount <= 0 || invalidConversion) {
+    const amount = parseInt(conversion.amount, 10) || 0;
+    const isInvalidConversion = amount % currentConversion.from != 0;
+    if (amount > commitment.amount || amount <= 0 || isInvalidConversion) {
       setInvalidConversion(true);
       return;
     }
@@ -78,7 +78,7 @@ const ConversionModal = (props) => {
 
   function onConfirm() {
     if (!currentConversion) return;
-    const sourceAmount = conversion.amount;
+    const sourceAmount = parseInt(conversion.amount, 10) || 0;
     // defense in depth.
     if (sourceAmount > commitment.amount || sourceAmount <= 0 || invalidConversion) {
       setInvalidConversion(true);

--- a/src/components/commitment/Modals/ConversionModal.test.js
+++ b/src/components/commitment/Modals/ConversionModal.test.js
@@ -29,6 +29,8 @@ const conversionResults = {
 describe("test conversion modal", () => {
   test("successful conversion of maximum amount", async () => {
     const onConvert = jest.fn((commitment, payload) => {
+      expect(payload.commitment.target_service).toEqual("targetServiceA");
+      expect(payload.commitment.target_resource).toEqual("targetResourceA");
       expect(commitment.amount).toEqual(10);
       expect(payload.commitment.target_amount).toEqual(6);
     });
@@ -91,6 +93,7 @@ describe("test conversion modal", () => {
   test("successful conversion of custom amount", async () => {
     const onConvert = jest.fn((commitment, payload) => {
       expect(commitment.amount).toEqual(10);
+      expect(payload.commitment.source_amount).toEqual(3);
       expect(payload.commitment.target_amount).toEqual(2);
     });
     const commitment = { ...initialCommitmentObject };
@@ -126,6 +129,108 @@ describe("test conversion modal", () => {
     fireEvent.change(conversionInput, { target: { value: 3 } });
     await waitFor(() => {
       expect(screen.getByText(/target amount: 2/i)).toBeInTheDocument();
+    });
+    fireEvent.change(confirmInput, { target: { value: "convert" } });
+    fireEvent.click(confirmButton);
+    expect(onConvert).toHaveBeenCalled();
+  });
+
+  test("conversion with unit", async () => {
+    const onConvert = jest.fn((commitment, payload) => {
+      expect(commitment.amount).toEqual(4096);
+      expect(payload.commitment.target_service).toEqual("targetServiceA");
+      expect(payload.commitment.target_resource).toEqual("targetResourceA");
+      expect(payload.commitment.source_amount).toEqual(4095);
+      expect(payload.commitment.target_amount).toEqual(2730);
+    });
+    const commitment = { ...initialCommitmentObject };
+    commitment.amount = 4096;
+    commitment.unit = "MiB";
+    commitment.duration = "1 year";
+    commitment.resource_name = "resourceA";
+    render(
+      <PortalProvider>
+        <ConversionModal
+          title="Convert Commitment"
+          subText="Convert"
+          commitment={commitment}
+          conversionResults={conversionResults}
+          onModalClose={() => {}}
+          onConvert={onConvert}
+        />
+      </PortalProvider>
+    );
+    expect(screen.getByText("4 GiB")).toBeInTheDocument();
+    const targetInput = screen.getByTestId("conversionSelect");
+    const conversionInput = screen.getByTestId("conversionInput");
+    const confirmInput = screen.getByTestId("confirmInput");
+    const confirmButton = screen.getByTestId("modalConfirm");
+    fireEvent.click(targetInput);
+    const conversion1 = screen.getByTestId("targetResourceA");
+    fireEvent.click(conversion1);
+    await waitFor(() => {
+      expect(screen.getByText(/target amount: 2.67 GiB/i)).toBeInTheDocument(); // 4095 * 3 / 2
+    });
+    expect(conversionInput).toHaveValue("4095");
+    // invalid conversion amount
+    fireEvent.change(conversionInput, { target: { value: 4096 } });
+    await waitFor(() => {
+      expect(screen.getByText(/please enter a valid amount./i)).toBeInTheDocument();
+    });
+    fireEvent.change(conversionInput, { target: { value: 4095 } });
+    await waitFor(() => {
+      expect(screen.getByText(/target amount: 2.67 GiB/i)).toBeInTheDocument();
+    });
+    fireEvent.change(confirmInput, { target: { value: "convert" } });
+    fireEvent.click(confirmButton);
+    expect(onConvert).toHaveBeenCalled();
+  });
+
+  test("conversion with non standard unit", async () => {
+    const onConvert = jest.fn((commitment, payload) => {
+      expect(commitment.amount).toEqual(5);
+      expect(payload.commitment.target_service).toEqual("targetServiceA");
+      expect(payload.commitment.target_resource).toEqual("targetResourceA");
+      expect(payload.commitment.source_amount).toEqual(3);
+      expect(payload.commitment.target_amount).toEqual(2);
+    });
+    const commitment = { ...initialCommitmentObject };
+    commitment.amount = 5;
+    commitment.unit = "128 GiB";
+    commitment.duration = "1 year";
+    commitment.resource_name = "resourceA";
+    render(
+      <PortalProvider>
+        <ConversionModal
+          title="Convert Commitment"
+          subText="Convert"
+          commitment={commitment}
+          conversionResults={conversionResults}
+          onModalClose={() => {}}
+          onConvert={onConvert}
+        />
+      </PortalProvider>
+    );
+    expect(screen.getByText("640 GiB")).toBeInTheDocument();
+    const targetInput = screen.getByTestId("conversionSelect");
+    const conversionInput = screen.getByTestId("conversionInput");
+    const confirmInput = screen.getByTestId("confirmInput");
+    const confirmButton = screen.getByTestId("modalConfirm");
+    fireEvent.click(targetInput);
+    const conversion1 = screen.getByTestId("targetResourceA");
+    fireEvent.click(conversion1);
+    await waitFor(() => {
+      expect(screen.getByText(/target amount: 256 GiB \(2 \* 128 GiB\)/i)).toBeInTheDocument(); // 2 * 128 GiB will be converted
+    });
+    expect(conversionInput).toHaveValue("3");
+    // invalid conversion amount
+    fireEvent.change(conversionInput, { target: { value: 6 } });
+    await waitFor(() => {
+      expect(screen.getByText(/please enter a valid amount./i)).toBeInTheDocument();
+    });
+    fireEvent.change(conversionInput, { target: { value: 3 } });
+    await waitFor(() => {
+      expect(screen.getByText(/target amount: 256 GiB \(2 \* 128 GiB\)/i)).toBeInTheDocument();
     });
     fireEvent.change(confirmInput, { target: { value: "convert" } });
     fireEvent.click(confirmButton);

--- a/src/components/commitment/Modals/ConversionModal.test.js
+++ b/src/components/commitment/Modals/ConversionModal.test.js
@@ -169,7 +169,7 @@ describe("test conversion modal", () => {
     const conversion1 = screen.getByTestId("targetResourceA");
     fireEvent.click(conversion1);
     await waitFor(() => {
-      expect(screen.getByText(/target amount: 2.67 GiB/i)).toBeInTheDocument(); // 4095 * 3 / 2
+      expect(screen.getByText(/target amount: 2.67 GiB/i)).toBeInTheDocument(); // 4095 * (2 / 3)
     });
     expect(conversionInput).toHaveValue("4095");
     // invalid conversion amount

--- a/src/components/commitment/Modals/DeleteModal.js
+++ b/src/components/commitment/Modals/DeleteModal.js
@@ -5,14 +5,13 @@ import React from "react";
 import { Modal, DataGrid, DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components";
 import BaseFooter from "./BaseComponents/BaseFooter";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
-import { valueWithUnit } from "../../../lib/unit";
-import { Unit } from "../../../lib/unit";
+import { createUnit, valueWithUnit } from "../../../lib/unit";
 
 const label = "font-semibold";
 
 const DeleteModal = (props) => {
   const { action, currentTab, title, subText, onModalClose, commitment } = props;
-  const unit = new Unit(commitment.unit);
+  const unit = createUnit(commitment?.unit);
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
     confirmationText: subText,
   });

--- a/src/components/commitment/Modals/MarketplaceModal.js
+++ b/src/components/commitment/Modals/MarketplaceModal.js
@@ -18,8 +18,7 @@ import useConfirmInput from "./BaseComponents/useConfirmInput";
 import { useGlobalStore, useDomainStore } from "../../StoreProvider";
 import { formatTimeISO8160 } from "../../../lib/utils";
 import { Scope } from "../../../lib/scope";
-import { valueWithUnit } from "../../../lib/unit";
-import { Unit } from "../../../lib/unit";
+import { createUnit, valueWithUnit } from "../../../lib/unit";
 import DebouncedSearchInput from "../../shared/DebouncedSearchInput";
 import { chunkProjects } from "../../../lib/utils";
 
@@ -38,7 +37,7 @@ const selectOptionStyles = `
 const MarketplaceModal = (props) => {
   const { action, title, subText, onModalClose, project, commitment } = props;
   const { amount, availability_zone, duration, expires_at, transfer_token } = commitment;
-  const unit = new Unit(commitment.unit);
+  const unit = createUnit(commitment?.unit);
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
     confirmationText: subText,
   });

--- a/src/components/commitment/Modals/MergeModal.js
+++ b/src/components/commitment/Modals/MergeModal.js
@@ -5,14 +5,14 @@ import React from "react";
 import BaseFooter from "./BaseComponents/BaseFooter";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
 import { Modal, DataGrid, DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components";
-import { Unit, valueWithUnit } from "../../../lib/unit";
+import { createUnit, valueWithUnit } from "../../../lib/unit";
 import { parseCommitmentDuration } from "../../../lib/parseCommitmentDurations";
 
 const label = "font-semibold";
 
 const MergeModal = (props) => {
   const { commitments = [] } = props;
-  const unit = new Unit(commitments[0].unit);
+  const unit = createUnit(commitments[0]?.unit);
   const { action, title, subText, onModalClose } = props;
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({ confirmationText: subText });
   const [mergeAmount, highestDuration] = React.useMemo(() => {

--- a/src/components/commitment/Modals/RenewModal.js
+++ b/src/components/commitment/Modals/RenewModal.js
@@ -5,7 +5,7 @@ import React from "react";
 import BaseFooter from "./BaseComponents/BaseFooter";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
 import { Modal, DataGrid, DataGridRow, DataGridCell } from "@cloudoperators/juno-ui-components";
-import { Unit, valueWithUnit } from "../../../lib/unit";
+import { createUnit, valueWithUnit } from "../../../lib/unit";
 import { formatTimeISO8160 } from "../../../lib/utils";
 
 const label = "font-semibold";
@@ -13,7 +13,7 @@ const label = "font-semibold";
 const RenewModal = (props) => {
   const { commitments = [] } = props;
   const isSingleCommitment = commitments.length == 1;
-  const unit = isSingleCommitment && new Unit(commitments[0].unit);
+  const unit = isSingleCommitment && createUnit(commitments[0]?.unit);
   const { open, action, title, subText, onModalClose } = props;
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({ confirmationText: subText });
 

--- a/src/components/commitment/Modals/TransferModal.js
+++ b/src/components/commitment/Modals/TransferModal.js
@@ -10,14 +10,13 @@ import {
   Checkbox,
   Select,
   Stack,
-  TextInput,
   SelectOption,
 } from "@cloudoperators/juno-ui-components";
 import BaseFooter from "./BaseComponents/BaseFooter";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
-import { valueWithUnit } from "../../../lib/unit";
-import { Unit } from "../../../lib/unit";
+import { createUnit, valueWithUnit } from "../../../lib/unit";
 import { TransferType } from "../../../lib/constants";
+import InputWithUnit from "../../shared/InputWithUnit";
 
 const label = "font-semibold";
 
@@ -31,7 +30,7 @@ const TransferModal = (props) => {
   const { metadata: originMeta } = currentProject || {};
   const { metadata: targetMeta } = transferProject || {};
   const isMoveAction = transferProject ? true : false;
-  const unit = new Unit(commitment.unit);
+  const unit = createUnit(commitment?.unit);
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
     confirmationText: subText,
   });
@@ -40,7 +39,7 @@ const TransferModal = (props) => {
   );
   const [splitCommitment, setSplitCommitment] = React.useState(false);
   const [invalidSplitInput, setInvalidSplitInput] = React.useState(false);
-  const splitInputRef = React.useRef(unit.format(commitment.amount, { ascii: true }));
+  const splitInputRef = React.useRef(unit.formatForInput(commitment.amount, { ascii: true }));
 
   function onSplitInput(e) {
     setInvalidSplitInput(false);
@@ -129,16 +128,15 @@ const TransferModal = (props) => {
           <div>
             <Stack>{"Amount to transfer: "}</Stack>
             <Stack>
-              <TextInput
-                data-testid="splitInput"
-                width="auto"
-                autoFocus
-                value={splitInputRef.current}
-                errortext={invalidSplitInput && "Please enter a valid amount."}
+              <InputWithUnit
+                unit={unit}
+                inputRef={splitInputRef}
+                invalid={invalidSplitInput}
+                errorText={"Please enter a valid amount."}
                 onChange={(e) => {
                   onSplitInput(e);
                 }}
-              />{" "}
+              />
             </Stack>
           </div>
         )}

--- a/src/components/commitment/Modals/TransferModal.test.js
+++ b/src/components/commitment/Modals/TransferModal.test.js
@@ -45,7 +45,93 @@ describe("test transfer modal", () => {
     expect(onTransfer).toHaveBeenCalled();
   });
 
-  test("Cluster/Domain level: transfer part of a commitment", () => {
+  test("transfer split commitment with unit", async () => {
+    const onTransfer = jest.fn((transferProject, commitment) => {
+      expect(transferProject).toBeFalsy();
+      expect(commitment.amount).toEqual(1024);
+      expect(commitment.duration).toEqual("1 year");
+    });
+    const confirmedCommitment = { ...initialCommitmentObject };
+    confirmedCommitment.amount = 2048;
+    confirmedCommitment.duration = "1 year";
+    confirmedCommitment.unit = "MiB";
+    render(
+      <PortalProvider>
+        <TransferModal
+          title="Transfer Commitment"
+          subText="Transfer"
+          onModalClose={onCancel}
+          onTransfer={onTransfer}
+          commitment={confirmedCommitment}
+          isProjectView={true}
+        />
+      </PortalProvider>
+    );
+    const confirmButton = screen.getByTestId(/modalConfirm/i);
+    const confirmInput = screen.getByTestId(/confirmInput/i);
+    expect(screen.getByText(/amount/i)).toBeInTheDocument();
+    expect(screen.getByText("2 GiB")).toBeInTheDocument();
+    expect(screen.getByText("1 year")).toBeInTheDocument();
+    act(() => {
+      screen.getByRole("checkbox").click();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("inputWithUnit")).toBeInTheDocument();
+    });
+    const splitInput = screen.getByTestId("inputWithUnit");
+    fireEvent.change(splitInput, { target: { value: "1024" } });
+    fireEvent.change(confirmInput, { target: { value: "transfer" } });
+    fireEvent.click(confirmButton);
+    expect(onTransfer).not.toHaveBeenCalled();
+    fireEvent.change(splitInput, { target: { value: "1 GiB" } });
+    fireEvent.click(confirmButton);
+    expect(onTransfer).toHaveBeenCalled();
+  });
+
+  test("transfer split commitment with non standard unit", async () => {
+    const onTransfer = jest.fn((transferProject, commitment) => {
+      expect(transferProject).toBeFalsy();
+      expect(commitment.amount).toEqual(1);
+      expect(commitment.duration).toEqual("1 year");
+    });
+    const confirmedCommitment = { ...initialCommitmentObject };
+    confirmedCommitment.amount = 2;
+    confirmedCommitment.duration = "1 year";
+    confirmedCommitment.unit = "128 GiB";
+    render(
+      <PortalProvider>
+        <TransferModal
+          title="Transfer Commitment"
+          subText="Transfer"
+          onModalClose={onCancel}
+          onTransfer={onTransfer}
+          commitment={confirmedCommitment}
+          isProjectView={true}
+        />
+      </PortalProvider>
+    );
+    const confirmButton = screen.getByTestId(/modalConfirm/i);
+    const confirmInput = screen.getByTestId(/confirmInput/i);
+    expect(screen.getByText(/amount/i)).toBeInTheDocument();
+    expect(screen.getByText("256 GiB")).toBeInTheDocument();
+    expect(screen.getByText("1 year")).toBeInTheDocument();
+    act(() => {
+      screen.getByRole("checkbox").click();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("inputWithUnit")).toBeInTheDocument();
+    });
+    const splitInput = screen.getByTestId("inputWithUnit");
+    fireEvent.change(splitInput, { target: { value: "1024 MiB" } });
+    fireEvent.change(confirmInput, { target: { value: "transfer" } });
+    fireEvent.click(confirmButton);
+    expect(onTransfer).not.toHaveBeenCalled();
+    fireEvent.change(splitInput, { target: { value: "1" } });
+    fireEvent.click(confirmButton);
+    expect(onTransfer).toHaveBeenCalled();
+  });
+
+  test("Cluster/Domain level: transfer part of a commitment", async () => {
     const onTransfer = jest.fn((transferProject, commitment) => {
       expect(transferProject).toBeTruthy();
       expect(commitment.amount).toEqual(5);
@@ -78,7 +164,10 @@ describe("test transfer modal", () => {
     act(() => {
       screen.getByRole("checkbox").click();
     });
-    const splitInput = screen.getByTestId(/splitInput/i);
+    await waitFor(() => {
+      expect(screen.getByTestId("inputWithUnit")).toBeInTheDocument();
+    });
+    const splitInput = screen.getByTestId("inputWithUnit");
     fireEvent.change(splitInput, { target: { value: 5 } });
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);

--- a/src/components/commitment/Modals/TransferReceiveModal.js
+++ b/src/components/commitment/Modals/TransferReceiveModal.js
@@ -17,7 +17,7 @@ import {
 import BaseFooter from "./BaseComponents/BaseFooter";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
 import useLimesGetRequest from "../../shared/useLimesGetRequest";
-import { Unit, valueWithUnit } from "../../../lib/unit";
+import { createUnit, valueWithUnit } from "../../../lib/unit";
 
 const label = "font-semibold";
 
@@ -46,7 +46,7 @@ const TransferReceiveModal = (props) => {
   });
   const { data, isFetching, isError, error } = commitmentData;
   const commitment = data?.commitment;
-  const unit = new Unit(data?.unit);
+  const unit = createUnit(commitment?.unit);
 
   React.useEffect(() => {
     setGetCommitment(false);

--- a/src/components/commitment/Modals/TransferReceiveModal.test.js
+++ b/src/components/commitment/Modals/TransferReceiveModal.test.js
@@ -6,7 +6,6 @@ import TransferReceiveModal from "./TransferReceiveModal";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { initialCommitmentObject } from "../../../lib/constants";
 
 const transferToken = "5ce23c72246fb03942ce004beb7302bb5f640776b9593211";
 
@@ -17,34 +16,30 @@ const queryClient = new QueryClient({
     },
   },
 });
-queryClient.setQueryDefaults(["commitmentByToken"], {
-  queryFn: () => {
-    return {
-      commitment: {
-        amount: 10,
-        service_type: "serviceTypeA",
-        resource_name: "resourceNameA",
-        transfer_token: transferToken,
-      },
-    };
-  },
-});
 
 describe("test transfer receive modal", () => {
   beforeEach(() => {
     queryClient.clear();
   });
   test("successful transfer", async () => {
+    queryClient.setQueryDefaults(["commitmentByToken"], {
+      queryFn: () => {
+        return {
+          commitment: {
+            amount: 10,
+            service_type: "serviceTypeA",
+            resource_name: "resourceNameA",
+            transfer_token: transferToken,
+          },
+        };
+      },
+    });
+
     const onReceive = jest.fn((project, commitment, transferToken) => {
       expect(project).toEqual({ metadata: { id: "projectA" } });
       expect(commitment.amount).toEqual(10);
       expect(transferToken).toEqual(transferToken);
     });
-    const commitment = { ...initialCommitmentObject };
-    commitment.amount = 10;
-    commitment.duration = "1 year";
-    commitment.service_type = "serviceTypeA";
-    commitment.resource_name = "resourceNameA";
     render(
       <PortalProvider>
         <QueryClientProvider client={queryClient}>
@@ -60,7 +55,6 @@ describe("test transfer receive modal", () => {
         </QueryClientProvider>
       </PortalProvider>
     );
-    // const confirmInput = screen.getByTestId(/confirmInput/i);
     const checkButton = screen.getByTestId("checkToken");
     const tokenInput = screen.getByTestId(/transferTokenInput/i);
     fireEvent.change(tokenInput, { target: { value: transferToken } });
@@ -77,5 +71,95 @@ describe("test transfer receive modal", () => {
     const clearButton = screen.getByTestId("clearToken");
     fireEvent.click(clearButton);
     expect(screen.queryByText(/commitment found/i)).toBe(null);
+  });
+
+  test("transfer with unit", async () => {
+    queryClient.setQueryDefaults(["commitmentByToken"], {
+      queryFn: () => {
+        return {
+          commitment: {
+            amount: 1024,
+            unit: "MiB",
+            service_type: "serviceTypeA",
+            resource_name: "resourceNameA",
+            transfer_token: transferToken,
+          },
+        };
+      },
+    });
+
+    const onReceive = jest.fn((project, commitment, transferToken) => {
+      expect(project).toEqual({ metadata: { id: "projectA" } });
+      expect(commitment.amount).toEqual(1024);
+      expect(transferToken).toEqual(transferToken);
+    });
+    render(
+      <PortalProvider>
+        <QueryClientProvider client={queryClient}>
+          <TransferReceiveModal
+            title="Receive Commitment"
+            subText="Receive"
+            currentProject={{ metadata: { id: "projectA" } }}
+            serviceType={"serviceTypeA"}
+            currentResource={{ name: "resourceNameA" }}
+            transferCommitment={onReceive}
+            onModalClose={() => {}}
+          />
+        </QueryClientProvider>
+      </PortalProvider>
+    );
+    const checkButton = screen.getByTestId("checkToken");
+    const tokenInput = screen.getByTestId(/transferTokenInput/i);
+    fireEvent.change(tokenInput, { target: { value: transferToken } });
+    fireEvent.click(checkButton);
+    await waitFor(() => {
+      expect(screen.getByText(/commitment found/i)).toBeInTheDocument();
+      expect(screen.getByText("1 GiB")).toBeInTheDocument();
+    });
+  });
+
+  test("transfer with non standard unit", async () => {
+    queryClient.setQueryDefaults(["commitmentByToken"], {
+      queryFn: () => {
+        return {
+          commitment: {
+            amount: 2,
+            unit: "128 GiB",
+            service_type: "serviceTypeA",
+            resource_name: "resourceNameA",
+            transfer_token: transferToken,
+          },
+        };
+      },
+    });
+
+    const onReceive = jest.fn((project, commitment, transferToken) => {
+      expect(project).toEqual({ metadata: { id: "projectA" } });
+      expect(commitment.amount).toEqual(256);
+      expect(transferToken).toEqual(transferToken);
+    });
+    render(
+      <PortalProvider>
+        <QueryClientProvider client={queryClient}>
+          <TransferReceiveModal
+            title="Receive Commitment"
+            subText="Receive"
+            currentProject={{ metadata: { id: "projectA" } }}
+            serviceType={"serviceTypeA"}
+            currentResource={{ name: "resourceNameA" }}
+            transferCommitment={onReceive}
+            onModalClose={() => {}}
+          />
+        </QueryClientProvider>
+      </PortalProvider>
+    );
+    const checkButton = screen.getByTestId("checkToken");
+    const tokenInput = screen.getByTestId(/transferTokenInput/i);
+    fireEvent.change(tokenInput, { target: { value: transferToken } });
+    fireEvent.click(checkButton);
+    await waitFor(() => {
+      expect(screen.getByText(/commitment found/i)).toBeInTheDocument();
+      expect(screen.getByText("256 GiB")).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/commitment/Modals/UpdateDurationModal.js
+++ b/src/components/commitment/Modals/UpdateDurationModal.js
@@ -5,14 +5,14 @@ import React from "react";
 import { DataGrid, DataGridRow, DataGridCell, Modal, Select, SelectOption } from "@cloudoperators/juno-ui-components";
 import BaseFooter from "./BaseComponents/BaseFooter";
 import { useCreateCommitmentStore } from "../../StoreProvider";
-import { Unit, valueWithUnit } from "../../../lib/unit";
+import { createUnit, valueWithUnit } from "../../../lib/unit";
 import useConfirmInput from "./BaseComponents/useConfirmInput";
 
 // This package is isolated in order to create a way to decouple the remaining modal components in the near future.
 const UpdateDurationModal = (props) => {
   const { title, onModalClose, commitment, subText, onUpdate } = props;
   const [selectedDuration, setSelectedDuration] = React.useState(null);
-  const unit = new Unit(commitment.unit);
+  const unit = createUnit(commitment?.unit);
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({
     confirmationText: subText,
   });

--- a/src/components/commitment/Operations/Actions.js
+++ b/src/components/commitment/Operations/Actions.js
@@ -27,13 +27,18 @@ const Actions = (props) => {
   }, [commitmentActions]);
 
   function updateActions(key, menuItem, toolTip) {
-    const newAction = { key: key, menuItem: menuItem, toolTip: toolTip };
-
     setCommitmentActions((commitmentActions) => {
-      return commitmentActions
-        .filter((action) => action.key !== key)
-        .concat(newAction)
-        .sort((a, b) => a.key.localeCompare(b.key));
+      // Filter out existing action with the same key
+      const filteredActions = commitmentActions.filter((action) => action.key !== key);
+
+      // Remove action when necessary
+      if (menuItem === null) {
+        return filteredActions;
+      }
+
+      // Add new action
+      const newAction = { key: key, menuItem: menuItem, toolTip: toolTip };
+      return filteredActions.concat(newAction).sort((a, b) => a.key.localeCompare(b.key));
     });
   }
 

--- a/src/components/commitment/Operations/Actions.test.js
+++ b/src/components/commitment/Operations/Actions.test.js
@@ -124,6 +124,61 @@ describe("test Action Operation", () => {
       expect(screen.queryByText(/cancel transfer/i)).not.toBe(null);
     });
   });
+  test("should remove cancel transfer action when transfer completes", async () => {
+    const commitment = { ...initialCommitmentObject };
+    commitment.confirmed_at = "123";
+    commitment.transfer_status = "unlisted";
+    commitment.transfer_token = "test_token_123";
+    const scope = new Scope({ projectID: "123", domainID: "456" });
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <Actions commitment={commitment} />
+          {children}
+        </StoreProvider>
+      </PortalProvider>
+    );
+    const { result, rerender } = renderHook(
+      () => ({
+        commitmentStore: useCreateCommitmentStore(),
+        commitmentStoreActions: createCommitmentStoreActions(),
+        globalStoreActions: globalStoreActions(),
+      }),
+      {
+        wrapper,
+      }
+    );
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+
+    const contextMenu = await waitFor(() => {
+      return screen.getByTitle(/more/i);
+    });
+
+    // Verify cancel transfer is shown when commitment is in transfer
+    userEvent.click(contextMenu);
+    await waitFor(() => {
+      expect(screen.queryByText(/transferring/i)).not.toBe(null);
+      expect(screen.queryByText(/cancel transfer/i)).not.toBe(null);
+    });
+
+    // transfer completion
+    delete commitment.transfer_status;
+    delete commitment.transfer_token;
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+
+    // Verify cancel transfer is removed
+    userEvent.click(contextMenu);
+    await waitFor(() => {
+      expect(screen.queryByText(/^transfer$/i)).not.toBe(null);
+      expect(screen.queryByText(/cancel transfer/i)).toBe(null);
+    });
+  });
+
   test("should render duration update action", async () => {
     const commitment = { ...initialCommitmentObject };
     commitment.duration = "1 year";

--- a/src/components/commitment/Operations/useTransferAction.js
+++ b/src/components/commitment/Operations/useTransferAction.js
@@ -33,11 +33,14 @@ const useTransferAction = (props) => {
     const menuItem = <MenuItemBuilder icon="upload" text={transferText} callBack={transferCommitment} />;
     updateActions("transfer", menuItem, toolTip);
 
-    if (!commitmentInTrasfer) return;
-    const cancelTransferMenuItem = (
-      <MenuItemBuilder icon="close" text={"Cancel transfer"} callBack={cancelTransferCommitment} />
-    );
-    updateActions("cancel_transfer", cancelTransferMenuItem, null);
+    if (commitmentInTrasfer) {
+      const cancelTransferMenuItem = (
+        <MenuItemBuilder icon="close" text={"Cancel transfer"} callBack={cancelTransferCommitment} />
+      );
+      updateActions("cancel_transfer", cancelTransferMenuItem, null);
+    } else {
+      updateActions("cancel_transfer", null, null);
+    }
   }, [commitment, scope]);
 };
 

--- a/src/components/commitment/Operations/useTransferAction.js
+++ b/src/components/commitment/Operations/useTransferAction.js
@@ -9,13 +9,13 @@ import { useGlobalStore, createCommitmentStoreActions } from "../../StoreProvide
 const useTransferAction = (props) => {
   const { commitment, updateActions } = props;
   const { transfer_status: transferStatus } = commitment;
-  const commitmentInTrasfer = transferStatus ? true : false;
+  const commitmentInTransfer = transferStatus ? true : false;
   const scope = useGlobalStore((state) => state.scope);
   const { setTransferredCommitment } = createCommitmentStoreActions();
   const { setTransferFromAndToProject } = createCommitmentStoreActions();
 
   function transferCommitment() {
-    setTransferFromAndToProject(commitmentInTrasfer ? TransferStatus.VIEW : TransferStatus.START);
+    setTransferFromAndToProject(commitmentInTransfer ? TransferStatus.VIEW : TransferStatus.START);
     setTransferredCommitment(commitment);
   }
 
@@ -25,15 +25,15 @@ const useTransferAction = (props) => {
   }
 
   React.useEffect(() => {
-    const toolTip = commitmentInTrasfer ? "ready for transfer" : null;
-    let transferText = commitmentInTrasfer ? "Transferring" : "Transfer";
-    if (!scope.isProject() && !commitmentInTrasfer) {
+    const toolTip = commitmentInTransfer ? "ready for transfer" : null;
+    let transferText = commitmentInTransfer ? "Transferring" : "Transfer";
+    if (!scope.isProject() && !commitmentInTransfer) {
       transferText = `${transferText} (Marketplace)`;
     }
     const menuItem = <MenuItemBuilder icon="upload" text={transferText} callBack={transferCommitment} />;
     updateActions("transfer", menuItem, toolTip);
 
-    if (commitmentInTrasfer) {
+    if (commitmentInTransfer) {
       const cancelTransferMenuItem = (
         <MenuItemBuilder icon="close" text={"Cancel transfer"} callBack={cancelTransferCommitment} />
       );

--- a/src/components/commitmentRenewal/CommitmentRenewal.js
+++ b/src/components/commitmentRenewal/CommitmentRenewal.js
@@ -14,7 +14,7 @@ import {
 } from "@cloudoperators/juno-ui-components/index";
 import RenewModal from "../commitment/Modals/RenewModal";
 import { t, formatTimeISO8160 } from "../../lib/utils";
-import { Unit, valueWithUnit } from "../../lib/unit";
+import { createUnit, valueWithUnit } from "../../lib/unit";
 import { categoryTitle } from "../paygAvailability/stylescss";
 import useSortTableData from "../../hooks/useSortTable";
 import { useMutation } from "@tanstack/react-query";
@@ -96,7 +96,7 @@ const CommitmentRenewal = (props) => {
   }
 
   function getTableData(c, showRenewable) {
-    const unit = new Unit(c.unit);
+    const unit = createUnit(c?.unit);
     return (
       <DataGridRow key={c.id}>
         <DataGridCell>{t(c.service_type)}</DataGridCell>

--- a/src/components/mainView/Category.js
+++ b/src/components/mainView/Category.js
@@ -5,6 +5,7 @@ import React from "react";
 import { t, sortByLogicalOrderAndName, tracksQuota } from "../../lib/utils";
 import Resource from "./Resource";
 import { ErrorBoundary } from "../../lib/ErrorBoundary";
+import { hwVersionScaleRx } from "../../lib/utils";
 
 const categoryTitle = `
     text-lg 
@@ -35,15 +36,36 @@ const Category = (props) => {
     return resources.filter((res) => res.editableResource === true);
   }, [resources]);
 
+  const specialUnitCoreNames = React.useMemo(() => {
+    const hwVersionResources = resources.filter((res) => hwVersionScaleRx.test(res.name));
+    const editableRamNames = hwVersionResources
+      .filter((res) => res.name.includes("ram") && res.editableResource)
+      .map((res) => res.name);
+    return hwVersionResources
+      .filter(
+        (res) =>
+          res.name.includes("cores") &&
+          !res.editableResource &&
+          editableRamNames.includes(res.name.replace("cores", "ram"))
+      )
+      .map((res) => res.name);
+  }, [resources]);
+
   return (
     (editableResources.length > 0 || advancedView) && (
       <div className="category-container mb-4">
         <h1 className={`category-title ${categoryTitle}`}>{t(props.categoryName)}</h1>
         <div className={`category-content ${categoryContent}`}>
           {sortByLogicalOrderAndName(advancedView ? resources : editableResources).map((res) => {
+            const withSpecialUnitInfo = specialUnitCoreNames.includes(res.name);
             return (
               <ErrorBoundary key={res.name}>
-                <Resource resource={res} {...forwardProps} tracksQuota={tracksQuota(res)} />
+                <Resource
+                  resource={res}
+                  {...forwardProps}
+                  tracksQuota={tracksQuota(res)}
+                  withSpecialUnitInfo={withSpecialUnitInfo}
+                />
               </ErrorBoundary>
             );
           })}

--- a/src/components/mainView/Category.js
+++ b/src/components/mainView/Category.js
@@ -36,6 +36,8 @@ const Category = (props) => {
     return resources.filter((res) => res.editableResource === true);
   }, [resources]);
 
+  // Identify cores resources that should display special unit info based on a corresponding editable ram resource and the absence of their own editability.
+  // Defense in depth: A category group normally contains only one pair of cores and ram resources, but the code accounts for multiple pairs.
   const specialUnitCoreNames = React.useMemo(() => {
     const hwVersionResources = resources.filter((res) => hwVersionScaleRx.test(res.name));
     const editableRamNames = hwVersionResources

--- a/src/components/mainView/Overview.test.js
+++ b/src/components/mainView/Overview.test.js
@@ -116,4 +116,72 @@ describe("Overview", () => {
       expect(window.location.hash).toEqual("#/area-1");
     });
   });
+
+  test("displays specialUnitInfo", () => {
+    localStorage.setItem("advancedView", "true");
+
+    const mockOverviewWithHwVersion = {
+      ...mockOverview,
+      areas: {
+        "area-1": ["service-a"],
+      },
+      categories: {
+        "service-a": ["category-x"],
+      },
+    };
+
+    const mockResource = (name, editableResource, unit = "") => ({
+      name,
+      editableResource,
+      unit,
+      per_az: [{ name: "az-1", usage: 10, quota: 100 }],
+      quota: 100,
+      usage: 10,
+    });
+
+    const mockCategoriesWithHwVersion = {
+      "category-x": {
+        area: "area-1",
+        resources: [
+          mockResource("hw_version_2151_cores", false),
+          mockResource("hw_version_2151_ram", true, "128 GiB"),
+          mockResource("hw_version_2152_cores", true),
+          mockResource("hw_version_2152_ram", true, "256 GiB"),
+          mockResource("hw_version_2153_cores", false),
+          mockResource("hw_version_2153_ram", false, "512 GiB"),
+        ],
+      },
+    };
+
+    render(
+      <StoreProvider>
+        <HashRouter>
+          <Routes>
+            <Route
+              path="/:currentArea?"
+              element={
+                <Overview
+                  overview={mockOverviewWithHwVersion}
+                  categories={mockCategoriesWithHwVersion}
+                  canEdit={true}
+                />
+              }
+            />
+          </Routes>
+        </HashRouter>
+      </StoreProvider>
+    );
+
+    // info should appear for cores resources with editable RAM counterparts
+    expect(screen.getByTestId("specialUnitInfo/hw_version_2151_cores")).toBeInTheDocument();
+    // should not have specialUnitInfo (Cores are commitable)
+    expect(screen.queryByTestId("specialUnitInfo/hw_version_2152_cores")).not.toBeInTheDocument();
+    // should not have specialUnitInfo (RAM counterpart is not editable)
+    expect(screen.queryByTestId("specialUnitInfo/hw_version_2153_cores")).not.toBeInTheDocument();
+
+    // specialUnitPill should appear for resources with special units (e.g.128 GiB)
+    expect(screen.getByTestId("specialUnitPill/hw_version_2151_ram")).toBeInTheDocument();
+    expect(screen.getByTestId("specialUnitPill/hw_version_2152_ram")).toBeInTheDocument();
+    expect(screen.getByTestId("specialUnitPill/hw_version_2153_ram")).toBeInTheDocument();
+  });
 });

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -5,7 +5,7 @@ import React from "react";
 import { useGlobalStore, useCreateCommitmentStore } from "../StoreProvider";
 import { t } from "../../lib/utils";
 import { CustomZones, PanelType } from "../../lib/constants";
-import { Button, Stack } from "@cloudoperators/juno-ui-components";
+import { Button, Pill, Stack } from "@cloudoperators/juno-ui-components";
 import { Link } from "react-router";
 import { ProjectBadges } from "../shared/LimesBadges";
 import { isAZUnaware, getResourceDurations } from "../../lib/utils";
@@ -14,6 +14,7 @@ import useResetCommitment from "../../hooks/useResetCommitment";
 import HistoricalUsage from "./subComponents/HistoricalUsage";
 import ForbidAutogrowth from "./subComponents/ForbidAutogrowth";
 import PhysicalUsage from "./subComponents/PhysicalUsage";
+import { Unit } from "../../lib/unit";
 
 const barGroupContainer = `
     self-stretch  
@@ -81,6 +82,7 @@ const Resource = (props) => {
     tracksQuota,
   } = props;
   const { unit: unitName, editableResource } = resource;
+  const unit = new Unit(unitName);
   const isCommittable = getResourceDurations(resource).length > 0 ? true : false;
   const scope = useGlobalStore((state) => state.scope);
   const displayName = t(resource.name);
@@ -112,6 +114,7 @@ const Resource = (props) => {
         >
           <Stack gap="2">
             <div className="m-auto">{displayName}</div>
+            {isPanelView && unit.isSpecialUnit && <Pill pillKeyLabel="Unit" pillValueLabel={unitName} />}
             {!isPanelView && (
               <Button
                 data-testid="detailedResourceInfo"
@@ -160,7 +163,10 @@ const Resource = (props) => {
             <ProjectBadges az={props.resource.per_az[0]} unit={unitName} displayValues={true} />
           )}
           <Stack className="w-full" distribution="between">
-            {<div className="text-xs text-sap-grey-4">Resource name: {resource.name}</div>}
+            <Stack gap="1">
+              {unit.isSpecialUnit && <Pill pillKeyLabel="Unit" pillValueLabel={unitName} />}
+              {<div className="text-xs text-sap-grey-4 self-center">Resource name: {resource.name}</div>}
+            </Stack>
             {scope.isProject() && isCommittable && <ForbidAutogrowth {...forbidAutogrowthForwardProps} />}
           </Stack>
         </Stack>

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -5,7 +5,7 @@ import React from "react";
 import { useGlobalStore, useCreateCommitmentStore } from "../StoreProvider";
 import { t } from "../../lib/utils";
 import { CustomZones, PanelType } from "../../lib/constants";
-import { Button, Pill, Stack } from "@cloudoperators/juno-ui-components";
+import { Button, Icon, Pill, Stack } from "@cloudoperators/juno-ui-components";
 import { Link } from "react-router";
 import { ProjectBadges } from "../shared/LimesBadges";
 import { isAZUnaware, getResourceDurations } from "../../lib/utils";
@@ -14,6 +14,7 @@ import useResetCommitment from "../../hooks/useResetCommitment";
 import HistoricalUsage from "./subComponents/HistoricalUsage";
 import ForbidAutogrowth from "./subComponents/ForbidAutogrowth";
 import PhysicalUsage from "./subComponents/PhysicalUsage";
+import ToolTipWrapper from "../shared/ToolTipWrapper";
 import { Unit } from "../../lib/unit";
 
 const barGroupContainer = `
@@ -80,6 +81,7 @@ const Resource = (props) => {
     serviceType,
     setIsMerging,
     tracksQuota,
+    withSpecialUnitInfo,
   } = props;
   const { unit: unitName, editableResource } = resource;
   const unit = new Unit(unitName);
@@ -116,7 +118,14 @@ const Resource = (props) => {
             <div className="truncate" title={displayName}>
               {displayName}
             </div>
-            {unit.isSpecialUnit && <Pill className="whitespace-nowrap" pillKeyLabel="Unit" pillValueLabel={unitName} />}
+            {unit.isSpecialUnit && (
+              <Pill
+                data-testid={`specialUnitPill/${resource.name}`}
+                className="whitespace-nowrap"
+                pillKeyLabel="Unit"
+                pillValueLabel={unitName}
+              />
+            )}
             {!isPanelView && (
               <Button
                 data-testid="detailedResourceInfo"
@@ -127,6 +136,20 @@ const Resource = (props) => {
                 }}
                 title={displayResourceInfo ? "hide info" : "display info for this resource"}
                 size="small"
+              />
+            )}
+            {withSpecialUnitInfo && (
+              <ToolTipWrapper
+                trigger={<Icon data-testid={`specialUnitInfo/${resource.name}`} icon="info" color="text-theme-info" />}
+                content={
+                  <span className="font-medium">
+                    <b>For this hardware version:</b>
+                    <br />
+                    Commitments for this resource are disabled.
+                    <br />
+                    Commitments should be created at the corresponding RAM resource.
+                  </span>
+                }
               />
             )}
           </Stack>

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -15,7 +15,7 @@ import HistoricalUsage from "./subComponents/HistoricalUsage";
 import ForbidAutogrowth from "./subComponents/ForbidAutogrowth";
 import PhysicalUsage from "./subComponents/PhysicalUsage";
 import ToolTipWrapper from "../shared/ToolTipWrapper";
-import { Unit } from "../../lib/unit";
+import { createUnit } from "../../lib/unit";
 
 const barGroupContainer = `
     self-stretch  
@@ -84,7 +84,7 @@ const Resource = (props) => {
     withSpecialUnitInfo,
   } = props;
   const { unit: unitName, editableResource } = resource;
-  const unit = new Unit(unitName);
+  const unit = createUnit(unitName);
   const isCommittable = getResourceDurations(resource).length > 0 ? true : false;
   const scope = useGlobalStore((state) => state.scope);
   const displayName = t(resource.name);
@@ -118,7 +118,7 @@ const Resource = (props) => {
             <div className="truncate" title={displayName}>
               {displayName}
             </div>
-            {unit.isSpecialUnit && (
+            {!unit.isStandardUnit && (
               <Pill
                 data-testid={`specialUnitPill/${resource.name}`}
                 className="whitespace-nowrap"

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -106,15 +106,17 @@ const Resource = (props) => {
       <div
         className={` ${props.isPanelView ? `az-panel-container ${azPanelContent}` : `az-main-container ${azContent}`}`}
       ></div>
-      <Stack distribution="between" className={`bar-header ${barHeader}`}>
+      <Stack distribution="between" gap="1" className={`bar-header ${barHeader}`}>
         <Stack
-          className={`bar-title ${barTitle} w-full`}
+          className={`bar-title ${barTitle} w-full min-w-0`}
           gap="1"
           distribution={canEdit && !editableResource && "between"}
         >
-          <Stack gap="2">
-            <div className="m-auto">{displayName}</div>
-            {isPanelView && unit.isSpecialUnit && <Pill pillKeyLabel="Unit" pillValueLabel={unitName} />}
+          <Stack className="w-full min-w-0" gap="2">
+            <div className="truncate" title={displayName}>
+              {displayName}
+            </div>
+            {unit.isSpecialUnit && <Pill className="whitespace-nowrap" pillKeyLabel="Unit" pillValueLabel={unitName} />}
             {!isPanelView && (
               <Button
                 data-testid="detailedResourceInfo"
@@ -129,15 +131,14 @@ const Resource = (props) => {
             )}
           </Stack>
         </Stack>
-        {canEdit && (
+        {canEdit && !isPanelView && (
           <Stack className="items-center" gap="1">
-            {canEdit && !isPanelView && editableResource && (
+            {editableResource && (
               <Link to={`/${props.area}/edit/${categoryName}/${props.resource.name}`} state={props}>
                 <Button
                   data-cy={`edit/${props.resource.name}`}
                   data-testid={`edit/${props.resource.name}`}
                   size="small"
-                  variant="subdued"
                   icon="edit"
                 >
                   {scope.isProject() ? "Manage" : "Commitments"}
@@ -149,7 +150,7 @@ const Resource = (props) => {
                 to={`/${props.area}/edit/${categoryName}/${props.resource.name}/${PanelType.quota.name}`}
                 state={props}
               >
-                <Button data-testid={"setMaxQuotaPanel"} className="ml-1" size="small" icon="edit">
+                <Button data-testid={"setMaxQuotaPanel"} size="small" icon="edit">
                   Quota
                 </Button>
               </Link>
@@ -164,7 +165,6 @@ const Resource = (props) => {
           )}
           <Stack className="w-full" distribution="between">
             <Stack gap="1">
-              {unit.isSpecialUnit && <Pill pillKeyLabel="Unit" pillValueLabel={unitName} />}
               {<div className="text-xs text-sap-grey-4 self-center">Resource name: {resource.name}</div>}
             </Stack>
             {scope.isProject() && isCommittable && <ForbidAutogrowth {...forbidAutogrowthForwardProps} />}

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -147,7 +147,7 @@ const Resource = (props) => {
                     <br />
                     Commitments for this resource are disabled.
                     <br />
-                    Commitments should be created at the corresponding RAM resource.
+                    Commitments should be created on the corresponding RAM resource only.
                   </span>
                 }
               />

--- a/src/components/mainView/subComponents/ForbidAutogrowth.js
+++ b/src/components/mainView/subComponents/ForbidAutogrowth.js
@@ -6,7 +6,7 @@ import { Icon, Message, Modal, Spinner, Switch } from "@cloudoperators/juno-ui-c
 import ToolTipWrapper from "../../shared/ToolTipWrapper";
 import { useMutation } from "@tanstack/react-query";
 import { projectStoreActions } from "../../StoreProvider";
-import { Unit } from "../../../lib/unit";
+import { createUnit } from "../../../lib/unit";
 
 const ForbidAutogrowth = (props) => {
   const { editMode = false } = props;
@@ -16,7 +16,7 @@ const ForbidAutogrowth = (props) => {
   const [showModal, setShowModal] = React.useState(false);
   const mutatation = useMutation({ mutationKey: ["forbidAutogrowth"] });
   const maxQuotaValue = resource?.max_quota;
-  const unit = new Unit(resource?.unit);
+  const unit = createUnit(resource?.unit);
 
   function handleAction(autogrowthForbidden) {
     const parseTarget = {

--- a/src/components/mainView/subComponents/PhysicalUsage.js
+++ b/src/components/mainView/subComponents/PhysicalUsage.js
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { Box, Icon, Stack, Tooltip, TooltipContent, TooltipTrigger } from "@cloudoperators/juno-ui-components";
-import { Unit } from "../../../lib/unit";
+import { createUnit } from "../../../lib/unit";
 import { getUsageForAZLevel } from "../../../lib/resourceBarValues";
 
 const docLink =
@@ -15,7 +15,7 @@ const PhysicalUsage = (props) => {
   const usage = getUsageForAZLevel(resource);
   const physicalUsage = resource?.physical_usage;
   const isWarning = physicalUsage > usage;
-  const unit = new Unit(unitName);
+  const unit = createUnit(unitName);
   const displayText = `Physical Usage: ${unit.format(physicalUsage)}`;
   const isSnapshot = name == "snapshot_capacity";
 

--- a/src/components/mainView/subComponents/PhysicalUsage.test.js
+++ b/src/components/mainView/subComponents/PhysicalUsage.test.js
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import PhysicalUsage from "./PhysicalUsage";
+import { render, screen } from "@testing-library/react";
+import { PortalProvider } from "@cloudoperators/juno-ui-components/index";
+
+describe("renders for snapshot_capacity resource", () => {
+  test("should display physical usage when physical_usage is present", () => {
+    const props = {
+      resource: {
+        name: "snapshot_capacity",
+        usage: 100,
+        physical_usage: 150,
+      },
+      unit: "GiB",
+    };
+
+    render(
+      <PortalProvider>
+        <PhysicalUsage {...props} />
+      </PortalProvider>
+    );
+
+    const physicalUsageText = screen.getByText("Physical Usage: 150 GiB");
+    const boxElement = physicalUsageText.closest(".bg-theme-warning");
+    expect(boxElement).toBeInTheDocument();
+  });
+
+  test("should not display physical usage for non-snapshot_capacity resources", () => {
+    const props = {
+      resource: {
+        name: "other_resource",
+        usage: 100,
+        physical_usage: 150,
+      },
+      unit: "GiB",
+    };
+
+    render(
+      <PortalProvider>
+        <PhysicalUsage {...props} />
+      </PortalProvider>
+    );
+
+    expect(screen.queryByText(/Physical Usage:/)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/paygAvailability/bigVM/PAYGResource.js
+++ b/src/components/paygAvailability/bigVM/PAYGResource.js
@@ -4,7 +4,7 @@
 import React from "react";
 import { Stack, Icon, Tooltip, TooltipContent, TooltipTrigger } from "@cloudoperators/juno-ui-components";
 import { t } from "../../../lib/utils";
-import { Unit } from "../../../lib/unit";
+import { createUnit } from "../../../lib/unit";
 import { isAZUnaware } from "../../../lib/utils";
 import { getTotalUncommittedUsage } from "../../../lib/resourceBarValues";
 
@@ -26,7 +26,7 @@ function createTooltip(resource, tooltipContent) {
 const PAYGResource = (props) => {
   const { resource, cerebro, az, azIndex } = props;
   const azValues = az;
-  const unit = new Unit(resource.unit);
+  const unit = createUnit(resource?.unit);
   const azUnaware = isAZUnaware(resource.per_az);
 
   // Guard clause - Prevent AZ unaware resource from displaying under other AZ's!

--- a/src/components/project/ProjectQuotaDetails.js
+++ b/src/components/project/ProjectQuotaDetails.js
@@ -6,7 +6,7 @@ import { useGlobalStore } from "../StoreProvider";
 import { DataGridCell, DataGridRow, Icon, Stack } from "@cloudoperators/juno-ui-components";
 import ToolTipWrapper from "../shared/ToolTipWrapper";
 import useMaxQuotaSets from "../shared/useMaxQuotaSets";
-import { Unit, valueWithUnit } from "../../lib/unit";
+import { createUnit, valueWithUnit } from "../../lib/unit";
 
 const ProjectQuotaDetails = (props) => {
   const { serviceType, project, resource, setMaxQuota } = props;
@@ -16,7 +16,7 @@ const ProjectQuotaDetails = (props) => {
   const quota = resource.quota;
   const forbidAutogrowth = resource?.forbid_autogrowth ?? false;
   const scope = useGlobalStore((state) => state.scope);
-  const unit = new Unit(resource.unit);
+  const unit = createUnit(resource?.unit);
   const { MaxQuotaInput, maxQuotaInputProps, MaxQuotaEdit, maxQuotaEditProps } = useMaxQuotaSets({
     project: project,
     resource: resource,
@@ -50,7 +50,7 @@ const ProjectQuotaDetails = (props) => {
           <MaxQuotaInput {...maxQuotaInputProps} />
         </Stack>
       </DataGridCell>
-      <DataGridCell>
+      <DataGridCell className="justify-start">
         <MaxQuotaEdit {...maxQuotaEditProps} />
       </DataGridCell>
     </DataGridRow>

--- a/src/components/project/ProjectQuotaDetails.test.js
+++ b/src/components/project/ProjectQuotaDetails.test.js
@@ -52,7 +52,7 @@ describe("test project quota details", () => {
     const editButton2 = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton2);
     const saveButton = screen.getByTestId("maxQuotaSave");
-    const quotaInput = screen.getByTestId("maxQuotaInput");
+    const quotaInput = screen.getByTestId("inputWithUnit");
     fireEvent.change(quotaInput, { target: { value: 2 } });
     fireEvent.click(saveButton);
     await waitFor(() => {

--- a/src/components/project/TableExport.js
+++ b/src/components/project/TableExport.js
@@ -13,7 +13,7 @@ import { createProjectExportWorkbook } from "./TableExportContents";
 const TableExport = (props) => {
   const { scope, labelFilter, service, currentResource, projects, filteredProjects, projectResourceAZMap } = props;
   const { unit: unitName } = currentResource;
-  const unit = React.useMemo(() => createUnit(unitName || ""), [unitName]);
+  const unit = createUnit(unitName || "");
   const domainData = useDomainStore((state) => state.domainData);
   const { metadata: domainMeta } = domainData ?? {};
   const [modalIsOpen, setModalIsOpen] = React.useState(false);

--- a/src/components/project/TableExport.js
+++ b/src/components/project/TableExport.js
@@ -5,7 +5,7 @@ import React from "react";
 import { Button } from "@cloudoperators/juno-ui-components/index";
 import TableExportModal from "./TableExportModal";
 import { useMutation, useQueries } from "@tanstack/react-query";
-import { Unit } from "../../lib/unit";
+import { createUnit } from "../../lib/unit";
 import { useDomainStore } from "../StoreProvider";
 import { labelTypes } from "../shared/LimesBadges";
 import { createProjectExportWorkbook } from "./TableExportContents";
@@ -13,7 +13,7 @@ import { createProjectExportWorkbook } from "./TableExportContents";
 const TableExport = (props) => {
   const { scope, labelFilter, service, currentResource, projects, filteredProjects, projectResourceAZMap } = props;
   const { unit: unitName } = currentResource;
-  const unit = React.useMemo(() => new Unit(unitName || ""), [unitName]);
+  const unit = React.useMemo(() => createUnit(unitName || ""), [unitName]);
   const domainData = useDomainStore((state) => state.domainData);
   const { metadata: domainMeta } = domainData ?? {};
   const [modalIsOpen, setModalIsOpen] = React.useState(false);

--- a/src/components/project/TableExportContents.js
+++ b/src/components/project/TableExportContents.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Workbook } from "@cj-tech-master/excelts";
-import { Unit } from "../../lib/unit";
+import { createUnit } from "../../lib/unit";
 import { formatTimeISO8160 } from "../../lib/utils";
 import { CustomZones } from "../../lib/constants";
 import tableStylings from "./TableExportStylings";
@@ -91,7 +91,7 @@ export async function createProjectExportWorkbook({ projectData, resourceInfo, d
     if (commitmentSheet && commitmentsIncluded) {
       const projectCommitments = commitmentsMap.get(metadata.id) || [];
       projectCommitments.forEach((commitment) => {
-        const unit = new Unit(commitment?.unit || "");
+        const unit = createUnit(commitment?.unit || "");
         if (!withAllCommitments) {
           if (commitment.resource_name !== currentResource.name) {
             return;

--- a/src/components/project/TableExportContents.test.js
+++ b/src/components/project/TableExportContents.test.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createProjectExportWorkbook } from "./TableExportContents";
-import { Unit } from "../../lib/unit";
+import { createUnit } from "../../lib/unit";
 
 // Mock the tableStylings module
 jest.mock("./TableExportStylings", () => ({
@@ -226,7 +226,7 @@ describe("createProjectExportWorkbook", () => {
     const commitmentsMap = new Map();
 
     const projectData = { projectsToReport, projectResourceAZMap, commitmentsMap };
-    const unit = new Unit("MiB");
+    const unit = createUnit("MiB");
     const resourceInfo = {
       currentResource: { name: "resource-1", unit: "MiB" },
       service: "service-1",

--- a/src/components/resourceBar/ResourceBarBuilder.js
+++ b/src/components/resourceBar/ResourceBarBuilder.js
@@ -5,7 +5,7 @@ import React from "react";
 import ResourceBar, { getAppliedBarColors } from "./ResourceBar";
 import ResourceInfo from "./ResourceInfo";
 import { Stack } from "@cloudoperators/juno-ui-components/index";
-import { Unit } from "../../lib/unit";
+import { createUnit } from "../../lib/unit";
 import { getBarLabel, getEmptyBarLabel, hasAnyBarValues } from "./resourceBarUtils";
 import useResourceBarValues, { ResourceBarType } from "../../hooks/useResourceBarValues";
 
@@ -19,7 +19,7 @@ const extraFillStyle = `bg-sap-purple-2`;
 const ResourceBarBuilder = (props) => {
   const { scope, categoryName, resource, az, unit: unitName, barType, isEditableResource } = { ...props };
   const { showToolTip = false, displayResourceInfo = false } = { ...props };
-  const unit = new Unit(unitName || "");
+  const unit = createUnit(unitName || "");
   const isGranular = barType === ResourceBarType.granular;
   const currentResource = isGranular ? az : resource;
   const { leftBar, rightBar } = useResourceBarValues(currentResource, barType);

--- a/src/components/resourceBar/ResourceInfo.js
+++ b/src/components/resourceBar/ResourceInfo.js
@@ -6,7 +6,7 @@ import { IntroBox } from "@cloudoperators/juno-ui-components/index";
 import { hasAnyBarValues } from "./resourceBarUtils";
 import { locateBaseQuotaAZ } from "../../lib/utils";
 import { CustomZones } from "../../lib/constants";
-import { Unit } from "../../lib/unit";
+import { createUnit } from "../../lib/unit";
 import {
   UnknownAZLabel,
   CommittedUsageLabels,
@@ -26,7 +26,7 @@ const ResourceInfo = (props) => {
     categoryName,
     resource,
     az,
-    unit = new Unit(""),
+    unit = createUnit(""),
     isEmptyBar,
     isGranular,
     isEditableResource,

--- a/src/components/resourceBar/ResourceInfo.test.js
+++ b/src/components/resourceBar/ResourceInfo.test.js
@@ -6,7 +6,7 @@ import ResourceInfo from "./ResourceInfo";
 import { screen } from "shadow-dom-testing-library";
 import { render } from "@testing-library/react";
 import { resourceBar } from "./ResourceBar";
-import { Unit } from "../../lib/unit";
+import { createUnit } from "../../lib/unit";
 import { CustomZones } from "../../lib/constants";
 import { Scope } from "../../lib/scope";
 
@@ -66,7 +66,7 @@ describe("Resource info tests", () => {
     const props = {
       resource: {},
       az: { name: "AZ1" },
-      unit: new Unit("MiB"),
+      unit: createUnit("MiB"),
       leftBar: { utilized: 1024, available: 1024 },
       rightBar: resourceBar,
     };
@@ -96,7 +96,7 @@ describe("Resource info tests", () => {
       resource: {},
       isEditableResource: true,
       az: { name: "AZ1" },
-      unit: new Unit("MiB"),
+      unit: createUnit("MiB"),
       leftBar: resourceBar,
       rightBar: { utilized: 1024, available: 1024 },
     };
@@ -146,7 +146,7 @@ describe("Resource info tests", () => {
         ],
       },
       az: null,
-      unit: new Unit("MiB"),
+      unit: createUnit("MiB"),
       leftBar: {},
       rightBar: {},
     };
@@ -196,7 +196,7 @@ describe("Resource info tests", () => {
         per_az: [{ name: CustomZones.ANY }, { name: "AZ1" }],
       },
       az: { name: "AZ1" },
-      unit: new Unit("MiB"),
+      unit: createUnit("MiB"),
       leftBar: {},
       rightBar: { available: -1024 },
     };
@@ -255,7 +255,7 @@ describe("Resource info tests", () => {
           per_az: [{ name: "AZ1", capacity }],
         },
         az: { name: "AZ1", capacity },
-        unit: new Unit("MiB"),
+        unit: createUnit("MiB"),
         leftBar: { utilized: 10, available: 40 },
         rightBar: { utilized: value, available: value },
       };
@@ -284,7 +284,7 @@ describe("Resource info tests", () => {
         per_az: [{ name: "AZ1", quota: 4096 }],
       },
       az: { name: "AZ1", quota: 4096 },
-      unit: new Unit("MiB"),
+      unit: createUnit("MiB"),
       leftBar: { utilized: 10, available: 40 },
       rightBar: { utilized: 10, available: 10 },
     };

--- a/src/components/shared/InputWithUnit.js
+++ b/src/components/shared/InputWithUnit.js
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import { Stack, TextInput } from "@cloudoperators/juno-ui-components";
+import { createUnit } from "../../lib/unit";
+
+const InputWithUnit = (props) => {
+  const {
+    unit = createUnit(""),
+    inputRef = { current: "" },
+    onChange = () => {},
+    invalid = false,
+    errorText = "",
+    ...textInputProps
+  } = props;
+  const inputValue = inputRef.current;
+  const [displayValue, setDisplayValue] = React.useState(inputValue);
+
+  function handleChange(e) {
+    if (inputRef) {
+      inputRef.current = e.target.value;
+      setDisplayValue(e.target.value);
+    }
+    onChange(e);
+  }
+
+  function getUnitConversion(input) {
+    if (!unit) return input;
+    const parsed = unit.parse(input);
+    if (parsed?.error) {
+      return 0;
+    }
+    return unit.format(input);
+  }
+
+  return (
+    <Stack direction="vertical">
+      <TextInput
+        data-testid="inputWithUnit"
+        value={displayValue}
+        onChange={handleChange}
+        errortext={invalid && errorText}
+        {...textInputProps}
+      />
+      {unit && !unit.isStandardUnit && (
+        <div data-testid="inputWithUnitInfo" className="mt-1 whitespace-nowrap text-xs text-sap-grey-4">
+          {`Amount: ${getUnitConversion(displayValue)}`}
+        </div>
+      )}
+    </Stack>
+  );
+};
+
+export default InputWithUnit;

--- a/src/components/shared/InputWithUnit.js
+++ b/src/components/shared/InputWithUnit.js
@@ -31,7 +31,7 @@ const InputWithUnit = (props) => {
     if (parsed?.error) {
       return 0;
     }
-    return unit.format(parsed);
+    return unit.format(parsed, { ascii: true });
   }
 
   return (

--- a/src/components/shared/InputWithUnit.js
+++ b/src/components/shared/InputWithUnit.js
@@ -31,7 +31,7 @@ const InputWithUnit = (props) => {
     if (parsed?.error) {
       return 0;
     }
-    return unit.format(input);
+    return unit.format(parsed);
   }
 
   return (

--- a/src/components/shared/InputWithUnit.test.js
+++ b/src/components/shared/InputWithUnit.test.js
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import InputWithUnit from "./InputWithUnit";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createUnit } from "../../lib/unit";
+
+describe("InputWithUnit", () => {
+  test("should react to value changes with standard unit", () => {
+    const inputRef = { current: "" };
+    const handleInput = jest.fn(() => {});
+    const unit = new createUnit("GiB");
+    render(<InputWithUnit inputRef={inputRef} onChange={() => handleInput()} unit={unit} />);
+    const input = screen.getByTestId("inputWithUnit");
+    fireEvent.change(input, { target: { value: "2 GiB" } });
+    expect(handleInput).toHaveBeenCalled();
+    expect(screen.queryByTestId("inputWithUnitInfo")).not.toBeInTheDocument();
+  });
+  test("should react to value changes with non standard unit", () => {
+    const inputRef = { current: "" };
+    const handleInput = jest.fn(() => {});
+    const unit = new createUnit("128 GiB");
+
+    render(<InputWithUnit inputRef={inputRef} onChange={() => handleInput()} unit={unit} />);
+    const input = screen.getByTestId("inputWithUnit");
+    fireEvent.change(input, { target: { value: 2 } });
+    expect(screen.getByTestId("inputWithUnitInfo")).toBeInTheDocument();
+    expect(handleInput).toHaveBeenCalled();
+    expect(inputRef.current).toEqual("2");
+  });
+});

--- a/src/components/shared/InputWithUnit.test.js
+++ b/src/components/shared/InputWithUnit.test.js
@@ -10,7 +10,7 @@ describe("InputWithUnit", () => {
   test("should react to value changes with standard unit", () => {
     const inputRef = { current: "" };
     const handleInput = jest.fn(() => {});
-    const unit = new createUnit("GiB");
+    const unit = createUnit("GiB");
     render(<InputWithUnit inputRef={inputRef} onChange={() => handleInput()} unit={unit} />);
     const input = screen.getByTestId("inputWithUnit");
     fireEvent.change(input, { target: { value: "2 GiB" } });
@@ -20,7 +20,7 @@ describe("InputWithUnit", () => {
   test("should react to value changes with non standard unit", () => {
     const inputRef = { current: "" };
     const handleInput = jest.fn(() => {});
-    const unit = new createUnit("128 GiB");
+    const unit = createUnit("128 GiB");
 
     render(<InputWithUnit inputRef={inputRef} onChange={() => handleInput()} unit={unit} />);
     const input = screen.getByTestId("inputWithUnit");

--- a/src/components/shared/LimesBadges.js
+++ b/src/components/shared/LimesBadges.js
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { Badge } from "@cloudoperators/juno-ui-components";
-import { Unit } from "../../lib/unit";
+import { createUnit } from "../../lib/unit";
 import { uncommittedUsage, unusedCommitments, getUnusedCommitmentRatio } from "../../lib/utils";
 
 export const labelTypes = Object.freeze({
@@ -46,7 +46,7 @@ const ProjectBadges = (props) => {
     return;
   }
 
-  const unit = new Unit(unitName);
+  const unit = createUnit(unitName);
   const pending = az.pending_commitments;
   const planned = az.planned_commitments;
 

--- a/src/components/shared/useMaxQuotaSets.js
+++ b/src/components/shared/useMaxQuotaSets.js
@@ -4,9 +4,10 @@
 import React from "react";
 import { useMutation } from "@tanstack/react-query";
 import { projectStoreActions } from "../StoreProvider";
-import { Button, Stack, TextInput } from "@cloudoperators/juno-ui-components";
+import { Button, Stack } from "@cloudoperators/juno-ui-components";
 import { createCommitmentStoreActions } from "../StoreProvider";
-import { Unit, valueWithUnit } from "../../lib/unit";
+import { createUnit, valueWithUnit } from "../../lib/unit";
+import InputWithUnit from "./InputWithUnit";
 
 const useMaxQuotaSets = (props) => {
   const { project = {}, resource = {}, serviceType = "", postMaxQuota = getMaxQuotaQuery() } = props;
@@ -17,8 +18,8 @@ const useMaxQuotaSets = (props) => {
     isLoading: false,
   });
   const maxQuota = resource?.max_quota;
-  const unit = new Unit(resource.unit);
-  const maxQuotaDefaultInput = unit.format(maxQuota || 0, { ascii: true });
+  const unit = createUnit(resource?.unit);
+  const maxQuotaDefaultInput = unit.formatForInput(maxQuota || 0, { ascii: true });
   const inputRef = React.useRef(maxQuotaDefaultInput);
 
   React.useEffect(() => {
@@ -58,7 +59,7 @@ const useMaxQuotaSets = (props) => {
     const domainID = project?.metadata.domainID || null;
     const projectID = project?.metadata.id;
     setMaxQuotaState({ ...maxQuotaState, isLoading: true });
-    postMaxQuota(parseTarget, domainID, projectID);
+    postMaxQuota(parseTarget, domainID, projectID, setMaxQuotaState);
   }
 
   function serializeProject(maxQuota) {
@@ -118,21 +119,18 @@ const MaxQuotaInput = (props) => {
     maxQuota = undefined,
     maxQuotaState = () => {},
     unit = "",
-    // Custumizations set by the direct caller.
-    reducedView = false,
   } = props;
   const { styles = "", wrapperStyles = "" } = props;
   const { isEditing = false, invalidInput = false } = maxQuotaState;
 
   return isEditing ? (
-    <TextInput
-      data-testid="maxQuotaInput"
-      className={`${styles} ${reducedView && invalidInput && "border-theme-danger"}`}
+    <InputWithUnit
+      className={styles}
       wrapperClassName={wrapperStyles}
-      value={inputRef.current}
-      invalid={!reducedView && invalidInput}
-      autoFocus={true}
+      inputRef={inputRef}
+      invalid={invalidInput}
       onChange={(e) => handleInput(e)}
+      unit={unit}
     />
   ) : maxQuota >= 0 ? (
     valueWithUnit(maxQuota, unit)
@@ -201,8 +199,9 @@ const MaxQuotaEdit = (props) => {
 function getMaxQuotaQuery() {
   const maxQuota = useMutation({ mutationKey: ["setMaxQuota"] });
   const { setRefetchProjectAPI } = projectStoreActions();
+  const { setToast } = createCommitmentStoreActions();
   // maxQuota can be set for a project with n services and m resources.
-  return function postMaxQuota(project, domainID, projectID) {
+  return function postMaxQuota(project, domainID, projectID, setMaxQuotaState) {
     if (!project) return;
 
     maxQuota.mutate(
@@ -213,6 +212,7 @@ function getMaxQuotaQuery() {
         },
         onError: (error) => {
           setToast(error.toString());
+          setMaxQuotaState({ invalidInput: false, isEditing: true, isLoading: false });
         },
       }
     );

--- a/src/components/shared/useMaxQuotaSets.test.js
+++ b/src/components/shared/useMaxQuotaSets.test.js
@@ -52,7 +52,7 @@ describe("test useMaxQuotaSets", () => {
     const editButton = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton);
     const saveButton = screen.getByTestId("maxQuotaSave");
-    const quotaInput = screen.getByTestId("maxQuotaInput");
+    const quotaInput = screen.getByTestId("inputWithUnit");
     fireEvent.change(quotaInput, { target: { value: 2 } });
     fireEvent.click(saveButton);
     await waitFor(() => {
@@ -72,21 +72,22 @@ describe("test useMaxQuotaSets", () => {
     const editButton = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton);
     const cancelButton = screen.getByTestId("maxQuotaCancel");
-    const quotaInput = screen.getByTestId("maxQuotaInput");
+    const quotaInput = screen.getByTestId("inputWithUnit");
     fireEvent.change(quotaInput, { target: { value: 2 } });
     fireEvent.click(cancelButton);
     const editButton2 = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton2);
-    const quotaInput2 = screen.getByTestId("maxQuotaInput");
+    const quotaInput2 = screen.getByTestId("inputWithUnit");
     expect(quotaInput2).toHaveValue("9");
   });
-  test("should display correct unit values", () => {
+  test("should display correct unit values", async () => {
     const project = { metadata: { name: "testProject", id: 12, domainID: 13 } };
     const resource = { usage: 512, quota: 1024, max_quota: 1024, unit: "MiB" };
+    const postMaxQuota = jest.fn(() => {});
     render(
       <PortalProvider>
         <StoreProvider>
-          <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} />
+          <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} postMaxQuota={postMaxQuota} />
         </StoreProvider>
       </PortalProvider>
     );
@@ -94,11 +95,36 @@ describe("test useMaxQuotaSets", () => {
     // false input (no unit)
     const editButton = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton);
-    const quotaInput = screen.getByTestId("maxQuotaInput");
+    const quotaInput = screen.getByTestId("inputWithUnit");
     fireEvent.change(quotaInput, { target: { value: 2 } });
     const saveButton = screen.getByTestId("maxQuotaSave");
     fireEvent.click(saveButton);
     expect(quotaInput.validity.tooShort).toBe(false);
+    await waitFor(() => {
+      expect(postMaxQuota).not.toHaveBeenCalled();
+    });
+  });
+  test("should display correct non standard unit values", async () => {
+    const project = { metadata: { name: "testProject", id: 12, domainID: 13 } };
+    const resource = { usage: 1, quota: 5, max_quota: 5, unit: "128 GiB" };
+    const postMaxQuota = jest.fn(() => {});
+    render(
+      <PortalProvider>
+        <StoreProvider>
+          <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} postMaxQuota={postMaxQuota} />
+        </StoreProvider>
+      </PortalProvider>
+    );
+    expect(screen.queryByText(/640 GiB/i)).not.toBe(null);
+    const editButton = screen.getByTestId("maxQuotaEdit");
+    fireEvent.click(editButton);
+    const quotaInput = screen.getByTestId("inputWithUnit");
+    fireEvent.change(quotaInput, { target: { value: 2 } });
+    const saveButton = screen.getByTestId("maxQuotaSave");
+    fireEvent.click(saveButton);
+    await waitFor(() => {
+      expect(postMaxQuota).toHaveBeenCalled();
+    });
   });
   test("reject value that is already set on the backend", async () => {
     const project = { metadata: { name: "testProject", id: 12, domainID: 13 } };
@@ -113,7 +139,7 @@ describe("test useMaxQuotaSets", () => {
     );
     const editButton = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton);
-    const quotaInput = screen.getByTestId("maxQuotaInput");
+    const quotaInput = screen.getByTestId("inputWithUnit");
     fireEvent.change(quotaInput, { target: { value: 10 } });
     const saveButton = screen.getByTestId("maxQuotaSave");
     fireEvent.click(saveButton);

--- a/src/lib/mocks/fixtures/project_api.json
+++ b/src/lib/mocks/fixtures/project_api.json
@@ -94,6 +94,73 @@
               "usage": 71
             },
             {
+              "name": "hw_version_2150_cores",
+              "category": "kvm_v2_generic",
+              "quota_distribution_model": "autogrow",
+              "per_az": {
+                "az-1a": {
+                  "quota": 4000,
+                  "usage": 4000,
+                  "historical_usage": {
+                    "min_usage": 3636,
+                    "max_usage": 4000,
+                    "duration": "48h"
+                  }
+                },
+                "az-1b": {
+                  "usage": 50,
+                  "quota": 50
+                },
+                "az-1d": {
+                  "usage": 50,
+                  "quota": 50
+                }
+              },
+              "quota": 4100,
+              "usable_quota": 4100,
+              "usage": 4100
+            },
+            {
+              "name": "hw_version_2150_ram",
+              "category": "kvm_v2_generic",
+              "unit": "128 GiB",
+              "quota_distribution_model": "autogrow",
+              "commitment_config": {
+                "durations": [
+                  "1 year",
+                  "2 years",
+                  "3 years"
+                ]
+              },
+              "per_az": {
+                "any": {
+                  "usage": 0,
+                  "quota": 1,
+                  "historical_usage": {
+                    "duration": "48 hours"
+                  }
+                },
+                "az-1a": {
+                  "committed": {
+                    "2 years": 1
+                  },
+                  "usage": 2,
+                  "quota": 3
+                },
+                "az-1b": {
+                  "usage": 2,
+                  "quota": 3
+                },
+                "az-1d": {
+                  "usage": 0,
+                  "quota": 3
+                }
+              },
+              "quota": 10,
+              "usable_quota": 10,
+              "usage": 4
+            },
+            {
               "name": "instances_hana_c120",
               "category": "per_flavor",
               "quota_distribution_model": "autogrow",

--- a/src/lib/unit.js
+++ b/src/lib/unit.js
@@ -45,39 +45,18 @@ const resolveSynonym = (str) => {
   return str;
 };
 
-export class Unit {
+// Unit class - handles regular units like "MiB", "GiB", "B", ""
+class Unit {
   constructor(name) {
-    // Special unit case: unit names starting with a digit (e.g., "128 GiB", "128GiB")
-    const match = name?.match(/^(?<value>\d+)\s*(?<unit>[a-zA-Z]+)$/);
-    this.isSpecialUnit = !!match;
-    if (this.isSpecialUnit) {
-      this.name = "";
-      const { value, unit } = match.groups;
-      const defaultUnitData = { base: "", steps: 0 };
-      this.specialUnitData = { value: parseInt(value, 10) || 0, ...(units[unit] || defaultUnitData) };
-      this.unitData = defaultUnitData;
-      const specialUnitBaseData = bases[this.specialUnitData.base] || { scale: "none" };
-      this.specialUnitScaleData = scales[specialUnitBaseData.scale];
-    } else {
-      this.name = name || "";
-      this.unitData = units[this.name] || { base: name, steps: 0 };
-    }
+    this.name = name || "";
+    this.isStandardUnit = true;
+    this.unitData = units[this.name] || { base: name, steps: 0 };
     const baseData = bases[this.unitData.base] || { scale: "none" };
     this.scaleData = scales[baseData.scale];
   }
 
-  // specialUserConversion takes the user input amount: X for a special unit and converts the result to display form.
-  specialUnitConversion(amount) {
-    const parsed = this.parse(amount);
-    if (parsed?.error) {
-      return null;
-    }
-    return this.specialUnitFormat(parsed);
-  }
-
-  // specialUnitFormat formats the total amount of a special unit with its actual unit.
-  specialUnitFormat(amount) {
-    return this.format(amount * this.specialUnitData.value, { specialUnit: true });
+  formatForInput(value, options) {
+    return this.format(value, options);
   }
 
   //Formats a value in this unit. May use bigger units for big values. For
@@ -91,38 +70,25 @@ export class Unit {
   //useful for input fields since the user is likely to type regular spaces.
   //
   format(value, options = {}) {
-    //convert value into bigger units if available
-    let steps, base, scaleData;
-    if (options.specialUnit && this.specialUnitData) {
-      steps = this.specialUnitData.steps;
-      base = this.specialUnitData.base;
-      scaleData = this.specialUnitScaleData;
-    } else {
-      steps = this.unitData.steps;
-      base = this.unitData.base;
-      scaleData = this.scaleData;
-    }
-
+    let steps = this.unitData.steps;
+    let base = this.unitData.base;
     const prefix = value < 0 ? "-" : "";
     value = Math.abs(value);
 
-    while (value >= scaleData.step && steps + 1 < scaleData.prefixes.length) {
-      value /= scaleData.step;
+    while (value >= this.scaleData.step && steps + 1 < this.scaleData.prefixes.length) {
+      value /= this.scaleData.step;
       steps += 1;
     }
 
-    const displayUnit = scaleData.prefixes[steps] + base;
+    const displayUnit = this.scaleData.prefixes[steps] + base;
 
     //round value down like printf("%.2f")
     value = Math.round(value * 100) / 100;
 
-    if (displayUnit == "") {
-      return prefix + value.toString();
-    } else {
-      //if possible, join with narrow no-break space instead of regular space
-      const space = options.ascii ? " " : "\u202F";
-      return prefix + value + space + displayUnit;
-    }
+    if (displayUnit == "") return prefix + value.toString();
+    //if possible, join with narrow no-break space instead of regular space
+    const space = options.ascii ? " " : "\u202F";
+    return prefix + value + space + displayUnit;
   }
 
   //Parses a string representation of a value in this unit. The unit may be
@@ -139,7 +105,7 @@ export class Unit {
   //    Unit('MiB').parse('10 whatever') => { error: 'syntax' }
   //    Unit('MiB').parse('10 KiB')      => { error: 'fractional-value' }
   //    Unit('MiB').parse('1024 KiB')    => 1
-  parse(input, commitment = true) {
+  parse(input, isCommitment = true) {
     //check overall syntax "<value> [<unit>]"
     const baseMatch = /^\s*([0-9.,]+)\s*([a-zA-Z]*)\s*$/.exec(input);
     if (baseMatch === null) {
@@ -151,7 +117,7 @@ export class Unit {
       return { error: "syntax" };
     }
 
-    if (baseMatch[1] == 0 && commitment) {
+    if (baseMatch[1] == 0 && isCommitment) {
       return { error: "cannot create empty commitments." };
     }
 
@@ -201,12 +167,59 @@ export class Unit {
   }
 }
 
-//Renders a value for display on the UI.
-export const valueWithUnit = (value, unit) => {
+// NonStandardUnit wraps Unit and handles units in the form of: "128 GiB"
+class NonStandardUnit {
+  constructor(name, multiplier, baseUnitName) {
+    this.multiplier = multiplier;
+    this.baseUnit = new Unit(baseUnitName);
+    this.name = name;
+    this.isStandardUnit = false;
+    this.isKnownBaseUnit = !!units[baseUnitName];
+  }
+
+  formatForInput(value) {
+    return value.toString();
+  }
+
+  // For known units (like "GiB"), multiply and format with base unit
+  // For unknown units (like "XYZ"), show count + full unit name
+  format(count, options = {}) {
+    if (this.isKnownBaseUnit) {
+      return this.baseUnit.format(count * this.multiplier, options);
+    }
+    const space = options.ascii ? " " : "\u202F";
+    return count + space + this.name;
+  }
+
+  parse(input, isCommitment = true) {
+    const baseMatch = /^\s*([0-9.,]+)\s*$/.exec(input);
+    if (!baseMatch) return { error: "syntax" };
+    if (baseMatch[1] == 0 && isCommitment) return { error: "cannot create empty commitments." };
+
+    const value = parseFloat(baseMatch[1].replace(/,/g, "."));
+    if (isNaN(value) || value != Math.floor(value)) return { error: "fractional-value" };
+    return value;
+  }
+}
+
+// Factory - creates appropriate unit type
+function createUnit(name) {
+  const match = name?.match(/^(?<value>\d+)\s*(?<unit>[a-zA-Z]+)$/);
+  if (match) {
+    const { value, unit } = match?.groups;
+    return new NonStandardUnit(name, parseInt(value, 10), unit);
+  }
+  return new Unit(name);
+}
+
+// Render helper
+const valueWithUnit = (value, unit) => {
   const title = unit.name !== "" ? `${value} ${unit.name}` : undefined;
   return (
     <span className="value-with-unit" title={title}>
-      {unit.isSpecialUnit ? unit.specialUnitFormat(value) : unit.format(value)}
+      {unit.format(value)}
     </span>
   );
 };
+
+export { Unit, NonStandardUnit, createUnit, valueWithUnit };

--- a/src/lib/unit.js
+++ b/src/lib/unit.js
@@ -48,17 +48,36 @@ const resolveSynonym = (str) => {
 export class Unit {
   constructor(name) {
     // Special unit case: unit names starting with a digit (e.g., "128 GiB", "128GiB")
-    // are treated as regular values. This is a KVM workaround
-    this.isSpecialUnit = /^\d/.test(name);
+    const match = name?.match(/^(?<value>\d+)\s*(?<unit>[a-zA-Z]+)$/);
+    this.isSpecialUnit = !!match;
     if (this.isSpecialUnit) {
       this.name = "";
-      this.unitData = { base: "", steps: 0 };
+      const { value, unit } = match.groups;
+      const defaultUnitData = { base: "", steps: 0 };
+      this.specialUnitData = { value: parseInt(value, 10) || 0, ...(units[unit] || defaultUnitData) };
+      this.unitData = defaultUnitData;
+      const specialUnitBaseData = bases[this.specialUnitData.base] || { scale: "none" };
+      this.specialUnitScaleData = scales[specialUnitBaseData.scale];
     } else {
       this.name = name || "";
       this.unitData = units[this.name] || { base: name, steps: 0 };
     }
     const baseData = bases[this.unitData.base] || { scale: "none" };
     this.scaleData = scales[baseData.scale];
+  }
+
+  // specialUserConversion takes the user input amount: X for a special unit and converts the result to display form.
+  specialUnitConversion(amount) {
+    const parsed = this.parse(amount);
+    if (parsed?.error) {
+      return null;
+    }
+    return this.specialUnitFormat(parsed);
+  }
+
+  // specialUnitFormat formats the total amount of a special unit with its actual unit.
+  specialUnitFormat(amount) {
+    return this.format(amount * this.specialUnitData.value, { specialUnit: true });
   }
 
   //Formats a value in this unit. May use bigger units for big values. For
@@ -73,16 +92,26 @@ export class Unit {
   //
   format(value, options = {}) {
     //convert value into bigger units if available
-    let steps = this.unitData.steps;
+    let steps, base, scaleData;
+    if (options.specialUnit && this.specialUnitData) {
+      steps = this.specialUnitData.steps;
+      base = this.specialUnitData.base;
+      scaleData = this.specialUnitScaleData;
+    } else {
+      steps = this.unitData.steps;
+      base = this.unitData.base;
+      scaleData = this.scaleData;
+    }
 
     const prefix = value < 0 ? "-" : "";
     value = Math.abs(value);
 
-    while (value >= this.scaleData.step && steps + 1 < this.scaleData.prefixes.length) {
-      value /= this.scaleData.step;
+    while (value >= scaleData.step && steps + 1 < scaleData.prefixes.length) {
+      value /= scaleData.step;
       steps += 1;
     }
-    const displayUnit = this.scaleData.prefixes[steps] + this.unitData.base;
+
+    const displayUnit = scaleData.prefixes[steps] + base;
 
     //round value down like printf("%.2f")
     value = Math.round(value * 100) / 100;
@@ -177,7 +206,7 @@ export const valueWithUnit = (value, unit) => {
   const title = unit.name !== "" ? `${value} ${unit.name}` : undefined;
   return (
     <span className="value-with-unit" title={title}>
-      {unit.format(value)}
+      {unit.isSpecialUnit ? unit.specialUnitFormat(value) : unit.format(value)}
     </span>
   );
 };

--- a/src/lib/unit.js
+++ b/src/lib/unit.js
@@ -45,7 +45,7 @@ const resolveSynonym = (str) => {
   return str;
 };
 
-// Unit class - handles regular units like "MiB", "GiB", "B", ""
+// Unit class - handles regular units like "B" "MiB", "GiB", ""
 class Unit {
   constructor(name) {
     this.name = name || "";
@@ -182,13 +182,13 @@ class NonStandardUnit {
   }
 
   // For known units (like "GiB"), multiply and format with base unit
-  // For unknown units (like "XYZ"), show count + full unit name
-  format(count, options = {}) {
+  // For unknown units (like "XYZ"), show value + full unit name
+  format(value, options = {}) {
     if (this.isKnownBaseUnit) {
-      return this.baseUnit.format(count * this.multiplier, options);
+      return this.baseUnit.format(value * this.multiplier, options);
     }
     const space = options.ascii ? " " : "\u202F";
-    return count + space + this.name;
+    return value + space + this.name;
   }
 
   parse(input, isCommitment = true) {

--- a/src/lib/unit.js
+++ b/src/lib/unit.js
@@ -177,7 +177,9 @@ class NonStandardUnit {
     this.isKnownBaseUnit = !!units[baseUnitName];
   }
 
-  formatForInput(value) {
+  // options parameter accepted for interface consistency
+  // eslint-disable-next-line no-unused-vars
+  formatForInput(value, options) {
     return value.toString();
   }
 
@@ -187,6 +189,7 @@ class NonStandardUnit {
     if (this.isKnownBaseUnit) {
       return this.baseUnit.format(value * this.multiplier, options);
     }
+    // Use regular ASCII space for input fields since users type regular spaces.
     const space = options.ascii ? " " : "\u202F";
     return value + space + this.name;
   }

--- a/src/lib/unit.test.js
+++ b/src/lib/unit.test.js
@@ -166,15 +166,26 @@ describe("Unit", () => {
       }
     });
 
-    // TODO: this is a temporary KVM workaround
-    // It ignores the actual unit and formats/parses into non-unit values.
-    it("treats special unit cases as regular values", () => {
+    it("handles special units", () => {
       const u = new Unit("128 GiB");
       expect(u.parse(`1024 ${u.unitData.base}`)).toEqual(1024);
+      expect(u.parse("1024")).toEqual(1024);
       expect(u.format(1024)).toEqual("1024");
       const u2 = new Unit("128GiB");
       expect(u2.parse(`1024 ${u2.unitData.base}`)).toEqual(1024);
       expect(u2.format(1024)).toEqual("1024");
+
+      // convert special units correctly:
+      expect(u.specialUnitConversion("2")).toMatch(/256\sGiB/);
+      expect(u.specialUnitConversion("invalidAmount")).toEqual(null);
+      expect(u.specialUnitFormat(0)).toMatch(/0\sGiB/);
+      expect(u.specialUnitFormat(8)).toMatch(/1\sTiB/);
+
+      // handles unknown special units
+      const u3 = new Unit("128 XYZ");
+      expect(u3.isSpecialUnit).toBe(true);
+      expect(u3.specialUnitData.base).toBe("");
+      expect(u.format(1024)).toEqual("1024");
     });
   });
 });

--- a/src/lib/unit.test.js
+++ b/src/lib/unit.test.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company
 // SPDX-License-Identifier: Apache-2.0
 
-import { Unit } from "./unit";
+import { createUnit, NonStandardUnit, Unit } from "./unit";
 
 describe("Unit", () => {
   describe(".render", () => {
@@ -26,6 +26,7 @@ describe("Unit", () => {
       const u = new Unit("B");
       for (const [input, output] of cases) {
         expect(u.format(input)).toMatch(output);
+        expect(u.formatForInput(input)).toMatch(output);
       }
     });
 
@@ -39,6 +40,7 @@ describe("Unit", () => {
       const u = new Unit("MiB");
       for (const [input, output] of cases) {
         expect(u.format(input)).toMatch(output);
+        expect(u.formatForInput(input)).toMatch(output);
       }
     });
   });
@@ -52,6 +54,7 @@ describe("Unit", () => {
     const u = new Unit("MiB");
     for (const [input, output] of cases) {
       expect(u.format(input)).toMatch(output);
+      expect(u.formatForInput(input)).toMatch(output);
     }
   });
 
@@ -165,29 +168,40 @@ describe("Unit", () => {
         expect(u.parse("42")).toEqual(errSyntax);
       }
     });
+  });
 
-    it("handles special units", () => {
-      // inputs can be handled as no-unit entities.
-      const u = new Unit("128 GiB");
-      expect(u.parse(`1024 ${u.unitData.base}`)).toEqual(1024);
+  describe("non standard units", () => {
+    it("tests unit factory", () => {
+      const u = createUnit("MiB");
+      expect(u instanceof Unit).toBe(true);
+      const u2 = createUnit("");
+      expect(u2 instanceof Unit).toBe(true);
+      const u3 = createUnit("128 GiB");
+      expect(u3 instanceof NonStandardUnit).toBe(true);
+      const u4 = createUnit("128GiB");
+      expect(u4 instanceof NonStandardUnit).toBe(true);
+    });
+    it("format and parse values correctly", () => {
+      const errSyntax = { error: "syntax" };
+      const errCommitment = { error: "cannot create empty commitments." };
+
+      const u = createUnit("128 GiB");
+      expect(u.format(1024)).toMatch(/128\sTiB/);
+      expect(u.formatForInput(1024)).toEqual("1024");
       expect(u.parse("1024")).toEqual(1024);
-      expect(u.format(1024)).toEqual("1024");
-      const u2 = new Unit("128GiB");
-      expect(u2.parse(`1024 ${u2.unitData.base}`)).toEqual(1024);
+      expect(u.parse("1024 GiB")).toEqual(errSyntax);
+      expect(u.parse("0")).toEqual(errCommitment);
+
+      const u2 = createUnit("128GiB");
+      expect(u2.format(1024)).toMatch(/128\sTiB/);
+      expect(u2.formatForInput(1024)).toEqual("1024");
       expect(u2.parse("1024")).toEqual(1024);
-      expect(u2.format(1024)).toEqual("1024");
+      expect(u2.parse("1024 GiB")).toEqual(errSyntax);
+      expect(u.parse("0")).toEqual(errCommitment);
 
-      // convert special units to display form correctly:
-      expect(u.specialUnitConversion("2")).toMatch(/256\sGiB/);
-      expect(u.specialUnitConversion("invalidAmount")).toEqual(null);
-      expect(u.specialUnitFormat(0)).toMatch(/0\sGiB/);
-      expect(u.specialUnitFormat(8)).toMatch(/1\sTiB/);
-
-      // handles unknown special units
-      const u3 = new Unit("128 XYZ");
-      expect(u3.isSpecialUnit).toBe(true);
-      expect(u3.specialUnitData.base).toBe("");
-      expect(u3.format(1024)).toEqual("1024");
+      const u3 = createUnit("128 XYZ");
+      expect(u3.format(5)).toMatch(/^5\s128\sXYZ$/);
+      expect(u3.parse(5)).toEqual(5);
     });
   });
 });

--- a/src/lib/unit.test.js
+++ b/src/lib/unit.test.js
@@ -167,15 +167,17 @@ describe("Unit", () => {
     });
 
     it("handles special units", () => {
+      // inputs can be handled as no-unit entities.
       const u = new Unit("128 GiB");
       expect(u.parse(`1024 ${u.unitData.base}`)).toEqual(1024);
       expect(u.parse("1024")).toEqual(1024);
       expect(u.format(1024)).toEqual("1024");
       const u2 = new Unit("128GiB");
       expect(u2.parse(`1024 ${u2.unitData.base}`)).toEqual(1024);
+      expect(u2.parse("1024")).toEqual(1024);
       expect(u2.format(1024)).toEqual("1024");
 
-      // convert special units correctly:
+      // convert special units to display form correctly:
       expect(u.specialUnitConversion("2")).toMatch(/256\sGiB/);
       expect(u.specialUnitConversion("invalidAmount")).toEqual(null);
       expect(u.specialUnitFormat(0)).toMatch(/0\sGiB/);
@@ -185,7 +187,7 @@ describe("Unit", () => {
       const u3 = new Unit("128 XYZ");
       expect(u3.isSpecialUnit).toBe(true);
       expect(u3.specialUnitData.base).toBe("");
-      expect(u.format(1024)).toEqual("1024");
+      expect(u3.format(1024)).toEqual("1024");
     });
   });
 });

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -6,6 +6,7 @@ import moment from "moment";
 
 const perFlavorRx = /^instances_(.+)$/;
 const hwVersionRx = /^hw_version_(\d+)_(.+)$/;
+export const hwVersionScaleRx = /^hw_version_215(.*)$/;
 
 // Translates API-level strings into user-readable UI strings,
 // e.g. "volumev2" -> "Block Storage".

--- a/src/quota/utils/resource.js
+++ b/src/quota/utils/resource.js
@@ -3,7 +3,7 @@
 
 // Generic functions for the label builders.
 
-import { Unit, valueWithUnit } from "../../lib/unit";
+import { createUnit, valueWithUnit } from "../../lib/unit";
 
 function getResource(resources, resourceName) {
   return resources.find((resource) => resource.name == resourceName);
@@ -15,7 +15,7 @@ function getRemainingQuota(resource) {
 }
 
 function getRemainingQuotaWithUnit(resource, resourceUnit) {
-  const unit = new Unit(resourceUnit);
+  const unit = createUnit(resourceUnit);
   const remainingQuota = getRemainingQuota(resource);
   return valueWithUnit(remainingQuota, unit);
 }


### PR DESCRIPTION
The inclusion of non standard units into the unit class caused an uncompfortable amount of case checks, which is why I decided to extract the non standard units into their own class. The caller side now creates the Unit object by calling the factory.
Unit formats which are meant for user inputs receive now use the method `formatForInput`. The regular `format` method is now solely used for unit UI displays.
During the implementation I noticed that the following actions make use of this:
* commitment creation
* commitment transfers
* max-quota settings
* commitment conversion

thereI noticed that the commitment conversion wasn't properly implemented for commitments with units. This wasn't a problem, because conversions are only available for non-unit resources. But this is now fixed and works for non-unit, unit and non-standard units.
The inputs and corresponding help text to translate the user input value to the unit are extracted and live within their own component `InputWithUnit`.
The remaining changes include the addition of a unit display at the resource, infos for non-commitable core resources while the RAM resource is commitable, minor component fixes that are connected to the unit migration and missing test cases.  