### PR TITLE
skip node/pnpm setup on PR close

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -27,11 +27,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Node.js
+        if: github.event.action != 'closed'
         uses: actions/setup-node@v6
         with:
           node-version: "24.x"
 
       - uses: pnpm/action-setup@v6
+        if: github.event.action != 'closed'
         name: Install pnpm
         with:
           cache: true


### PR DESCRIPTION
The setups are not needed and can cause errors on expired cache reads when a PR is closed.