### PR TITLE
fix modal multicklick bug

### DIFF
--- a/.changeset/khaki-socks-hunt.md
+++ b/.changeset/khaki-socks-hunt.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+fix action modal multiclick bug - implement execution lock

--- a/src/components/commitment/Modals/BaseComponents/BaseFooter.js
+++ b/src/components/commitment/Modals/BaseComponents/BaseFooter.js
@@ -14,15 +14,31 @@ const BaseFooter = (props) => {
       return;
     },
   } = props;
+  const executionLock = React.useRef(false);
+  const [isExecuting, setIsExecuting] = React.useState(false);
 
-  function onConfirm() {
+  async function onConfirm() {
+    if (executionLock.current) return;
+    executionLock.current = true;
+    setIsExecuting(true);
     for (const guardFn of guardFns) {
-      if (typeof guardFn !== "function") return;
+      if (typeof guardFn !== "function") {
+        executionLock.current = false;
+        setIsExecuting(false);
+        return;
+      }
       if (!guardFn()) {
+        executionLock.current = false;
+        setIsExecuting(false);
         return;
       }
     }
-    actionFn();
+    try {
+      await actionFn();
+    } finally {
+      executionLock.current = false;
+      setIsExecuting(false);
+    }
   }
 
   return (
@@ -31,7 +47,7 @@ const BaseFooter = (props) => {
         <Button
           data-testid="modalConfirm"
           label="Confirm"
-          disabled={disabled}
+          disabled={disabled || isExecuting}
           variant={variant}
           onClick={() => onConfirm()}
         />

--- a/src/components/commitment/Modals/BaseComponents/BaseFooter.test.js
+++ b/src/components/commitment/Modals/BaseComponents/BaseFooter.test.js
@@ -3,7 +3,7 @@
 
 import React from "react";
 import BaseFooter from "./BaseFooter";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { Modal } from "@cloudoperators/juno-ui-components";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
 
@@ -21,49 +21,52 @@ const UseExampleCmp = ({ guardFns, actionFn, disabled = false }) => {
 };
 
 describe("test Footer", () => {
-  test("function execution", () => {
+  test("function execution", async () => {
     console.log = jest.fn();
     const guardFns = [
       () => {
         return true;
       },
     ];
-    const actionFn = () => {
-      console.log("actioned");
-    };
+    const actionFn = jest.fn().mockResolvedValue(undefined);
     render(<UseExampleCmp guardFns={guardFns} actionFn={actionFn} />);
     const button = screen.getByTestId(/modalConfirm/i);
-    fireEvent.click(button);
-    expect(console.log).toHaveBeenCalledWith("actioned");
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    await waitFor(() => {
+      expect(actionFn).toHaveBeenCalled();
+    });
   });
 
-  test("negative function execution", () => {
-    console.log = jest.fn();
+  test("negative function execution", async () => {
+    const actionFn = jest.fn().mockResolvedValue(undefined);
     const guardFns = [
       () => {
         return false;
       },
     ];
-    const actionFn = () => {
-      console.log("actioned");
-    };
     render(<UseExampleCmp guardFns={guardFns} actionFn={actionFn} />);
     const button = screen.getByTestId(/modalConfirm/i);
-    fireEvent.click(button);
-    expect(console.log).not.toHaveBeenCalledWith("actioned");
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(actionFn).not.toHaveBeenCalled();
   });
 
-  test("no props and cancel modal", () => {
+  test("no props and cancel modal", async () => {
     render(<UseExampleCmp />);
     const confirm = screen.getByTestId(/modalConfirm/i);
     const close = screen.getByTestId(/modalCancel/i);
-    fireEvent.click(confirm);
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
     expect(confirm).toBeInTheDocument();
     fireEvent.click(close);
     expect(close).toBeInTheDocument();
   });
 
-  test("no action fn input", () => {
+  test("no action fn input", async () => {
     const guardFns = [
       () => {
         return true;
@@ -71,43 +74,68 @@ describe("test Footer", () => {
     ];
     render(<UseExampleCmp guardFns={guardFns} />);
     const confirm = screen.getByTestId(/modalConfirm/i);
-    fireEvent.click(confirm);
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
     expect(confirm).toBeInTheDocument();
   });
 
-  test("guardFns contain no function", () => {
+  test("guardFns contain no function", async () => {
     const guardFns = [true];
     render(<UseExampleCmp guardFns={guardFns} />);
     const confirm = screen.getByTestId(/modalConfirm/i);
-    fireEvent.click(confirm);
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
     expect(confirm).toBeInTheDocument();
   });
 
-  test("invalid guardFn input", () => {
-    console.log = jest.fn();
+  test("invalid guardFn input", async () => {
+    const actionFn = jest.fn().mockResolvedValue(undefined);
     const guardFns = [false];
-    const actionFn = () => {
-      console.log("actioned");
-    };
     render(<UseExampleCmp guardFns={guardFns} actionFn={actionFn} />);
     const button = screen.getByTestId(/modalConfirm/i);
-    fireEvent.click(button);
-    expect(console.log).not.toHaveBeenCalled();
+    await act(async () => {
+      fireEvent.click(button);
+    });
+    expect(actionFn).not.toHaveBeenCalled();
   });
 
-  test("disabled confirm button", () => {
-    console.log = jest.fn();
+  test("disabled confirm button", async () => {
+    const actionFn = jest.fn().mockResolvedValue(undefined);
     const guardFns = [
       () => {
         return true;
       },
     ];
-    const actionFn = () => {
-      console.log("actioned");
-    };
     render(<UseExampleCmp guardFns={guardFns} actionFn={actionFn} disabled={true} />);
     const button = screen.getByTestId(/modalConfirm/i);
     fireEvent.click(button);
-    expect(console.log).not.toHaveBeenCalled();
+    expect(actionFn).not.toHaveBeenCalled();
+  });
+
+  test("multiple rapid clicks only trigger action once", async () => {
+    let resolveAction;
+    const actionFn = jest.fn().mockImplementation(() => {
+      return new Promise((resolve) => {
+        resolveAction = resolve;
+      });
+    });
+    const guardFns = [() => true];
+    render(<UseExampleCmp guardFns={guardFns} actionFn={actionFn} />);
+    const button = screen.getByTestId(/modalConfirm/i);
+
+    // Simulate rapid multiple clicks
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    // Action should only be called once despite multiple clicks
+    expect(actionFn).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      resolveAction();
+    });
   });
 });

--- a/src/components/commitment/Modals/CommitmentModal.js
+++ b/src/components/commitment/Modals/CommitmentModal.js
@@ -48,7 +48,7 @@ const CommitmentModal = (props) => {
   const formattedDate = formatTimeISO8160(moment(selectedDate).unix());
   const notifyOnConfirm = React.useRef(false);
 
-  function onConfirm() {
+  async function onConfirm() {
     if (!selectedDate) return;
     // don't send a durationLabel for the UI to the API.
     delete commitment?.durationLabel;
@@ -67,9 +67,9 @@ const CommitmentModal = (props) => {
     // The API confirms commitments without confirm_by instantly.
     const sendConfirmBy = showCalendar;
     if (sendConfirmBy) {
-      action(confirm_by, notifyOnConfirm.current);
+      return action(confirm_by, notifyOnConfirm.current);
     } else {
-      action();
+      return action();
     }
   }
 

--- a/src/components/commitment/Modals/CommitmentModal.test.js
+++ b/src/components/commitment/Modals/CommitmentModal.test.js
@@ -3,14 +3,14 @@
 
 import React from "react";
 import moment from "moment";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
 import { initialCommitmentObject } from "../../../lib/constants";
 import CommitmentModal from "./CommitmentModal";
 
 // If debugging is necessary, use screen.debug(undefined, Infinity) to get the complete componenent log.
 describe("test commitment creation modal", () => {
-  test("no capacity commitment creation with no minConfirm date should be 60 seconds in the future", () => {
+  test("no capacity commitment creation with no minConfirm date should be 60 seconds in the future", async () => {
     Date.now = jest.fn(() => new Date("2024-01-01T00:00:00.000Z"));
     const onConfirm = jest.fn((confirm_by) => {
       expect(confirm_by).toEqual(moment(new Date("2024-01-01T00:01:00.000Z")).utc().unix());
@@ -46,7 +46,9 @@ describe("test commitment creation modal", () => {
     expect(screen.getByTestId("noCapacityWarning")).toBeInTheDocument();
     fireEvent.change(confirmInput, { target: { value: "commit" } });
     fireEvent.click(confirmButton);
-    expect(onConfirm).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
 
     // Rerender with marketplace commitments
 
@@ -69,7 +71,7 @@ describe("test commitment creation modal", () => {
     );
     expect(screen.queryByTestId("marketplaceInfo")).not.toBeInTheDocument();
   });
-  test("same day commit", () => {
+  test("same day commit", async () => {
     Date.now = jest.fn(() => new Date("2024-01-01T00:00:00.000Z"));
     const onConfirm = jest.fn((confirm_by) => {
       expect(confirm_by).toEqual(moment(new Date("2024-01-01T00:00:00.000Z")).utc().unix());
@@ -100,9 +102,11 @@ describe("test commitment creation modal", () => {
     expect(screen.getByText(/January 2024/i)).toBeInTheDocument();
     fireEvent.change(confirmInput, { target: { value: "commit" } });
     fireEvent.click(confirmButton);
-    expect(onConfirm).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
   });
-  test("create commitment in the future", () => {
+  test("create commitment in the future", async () => {
     Date.now = jest.fn(() => new Date("2024-01-01T00:00:00.000Z"));
     const onConfirm = jest.fn((confirm_by) => {
       expect(confirm_by).toEqual(moment(new Date("2024-01-31T00:00:00.000Z")).utc().unix());
@@ -141,7 +145,9 @@ describe("test commitment creation modal", () => {
     expect(onConfirm).not.toHaveBeenCalled();
     fireEvent.change(confirmInput, { target: { value: "commit" } });
     fireEvent.click(confirmButton);
-    expect(onConfirm).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalled();
+    });
   });
 
   test("open and close calendar", () => {

--- a/src/components/commitment/Modals/ConversionModal.js
+++ b/src/components/commitment/Modals/ConversionModal.js
@@ -76,7 +76,7 @@ const ConversionModal = (props) => {
     setCurrentConversion(conversion);
   }
 
-  function onConfirm() {
+  async function onConfirm() {
     if (!currentConversion) return;
     const sourceAmount = parseInt(conversion.amount, 10) || 0;
     // defense in depth.
@@ -92,7 +92,7 @@ const ConversionModal = (props) => {
         target_amount: targetAmount,
       },
     };
-    onConvert(commitment, payload);
+    return onConvert(commitment, payload);
   }
 
   return (

--- a/src/components/commitment/Modals/ConversionModal.test.js
+++ b/src/components/commitment/Modals/ConversionModal.test.js
@@ -132,7 +132,9 @@ describe("test conversion modal", () => {
     });
     fireEvent.change(confirmInput, { target: { value: "convert" } });
     fireEvent.click(confirmButton);
-    expect(onConvert).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onConvert).toHaveBeenCalled();
+    });
   });
 
   test("conversion with unit", async () => {
@@ -183,7 +185,9 @@ describe("test conversion modal", () => {
     });
     fireEvent.change(confirmInput, { target: { value: "convert" } });
     fireEvent.click(confirmButton);
-    expect(onConvert).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onConvert).toHaveBeenCalled();
+    });
   });
 
   test("conversion with non standard unit", async () => {
@@ -234,6 +238,8 @@ describe("test conversion modal", () => {
     });
     fireEvent.change(confirmInput, { target: { value: "convert" } });
     fireEvent.click(confirmButton);
-    expect(onConvert).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onConvert).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/commitment/Modals/DeleteModal.js
+++ b/src/components/commitment/Modals/DeleteModal.js
@@ -16,8 +16,8 @@ const DeleteModal = (props) => {
     confirmationText: subText,
   });
 
-  function onDelete() {
-    action(commitment);
+  async function onDelete() {
+    return action(commitment);
   }
 
   return (

--- a/src/components/commitment/Modals/MarketplaceModal.js
+++ b/src/components/commitment/Modals/MarketplaceModal.js
@@ -76,9 +76,9 @@ const MarketplaceModal = (props) => {
     return chunks.length > 0 ? chunks : [[]];
   }, [sortedProjects]);
 
-  function onConfirm() {
+  async function onConfirm() {
     if (disabled) return;
-    action(targetProject, commitment, transfer_token);
+    await action(targetProject, commitment, transfer_token);
     onModalClose();
   }
 

--- a/src/components/commitment/Modals/MarketplaceModal.test.js
+++ b/src/components/commitment/Modals/MarketplaceModal.test.js
@@ -60,7 +60,7 @@ describe("MarketplaceModal", () => {
     expect(screen.getByText("1970-01-01")).toBeInTheDocument();
   });
 
-  test("should call the action function when the confirm button is clicked", () => {
+  test("should call the action function when the confirm button is clicked", async () => {
     jest.spyOn(store, "useGlobalStore").mockImplementation(mockGlobalStore(false, true));
     jest.spyOn(store, "useDomainStore").mockImplementation(mockDomainStore([]));
 
@@ -73,10 +73,12 @@ describe("MarketplaceModal", () => {
     const confirmInput = screen.getByTestId(/confirmInput/i);
     fireEvent.change(confirmInput, { target: { value: "receive" } });
     fireEvent.click(screen.getByText("Confirm"));
-    expect(mockProps.action).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockProps.action).toHaveBeenCalled();
+    });
   });
 
-  test("should call the close function when the cancel button is clicked", async () => {
+  test("should call the close function when the cancel button is clicked", () => {
     jest.spyOn(store, "useGlobalStore").mockImplementation(mockGlobalStore(false, true));
     jest.spyOn(store, "useDomainStore").mockImplementation(mockDomainStore([]));
 
@@ -127,7 +129,9 @@ describe("MarketplaceModal", () => {
     let confirmInput = screen.getByTestId(/confirmInput/i);
     fireEvent.change(confirmInput, { target: { value: "receive" } });
     fireEvent.click(confirmButton);
-    expect(mockProps.action).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockProps.action).toHaveBeenCalled();
+    });
   });
 
   test("Domain level: should provide the correct target projects", async () => {
@@ -168,7 +172,9 @@ describe("MarketplaceModal", () => {
     let confirmInput = screen.getByTestId(/confirmInput/i);
     fireEvent.change(confirmInput, { target: { value: "receive" } });
     fireEvent.click(confirmButton);
-    expect(mockProps.action).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockProps.action).toHaveBeenCalled();
+    });
   });
 
   test("should filter projects based on search input", async () => {

--- a/src/components/commitment/Modals/MergeModal.js
+++ b/src/components/commitment/Modals/MergeModal.js
@@ -27,10 +27,10 @@ const MergeModal = (props) => {
     return [mergeAmount, highestDuration];
   }, [commitments]);
 
-  function onMerge() {
+  async function onMerge() {
     if (commitments.length < 2) return;
     const payload = { commitment_ids: commitments.map((c) => c.id) };
-    action(payload);
+    return action(payload);
   }
 
   return (

--- a/src/components/commitment/Modals/RenewModal.js
+++ b/src/components/commitment/Modals/RenewModal.js
@@ -17,8 +17,8 @@ const RenewModal = (props) => {
   const { open, action, title, subText, onModalClose } = props;
   const { ConfirmInput, inputProps, checkInput } = useConfirmInput({ confirmationText: subText });
 
-  function onRenew() {
-    action(commitments);
+  async function onRenew() {
+    return action(commitments);
   }
 
   return (

--- a/src/components/commitment/Modals/TransferCancelModal.js
+++ b/src/components/commitment/Modals/TransferCancelModal.js
@@ -3,20 +3,21 @@
 
 import React from "react";
 import { Modal } from "@cloudoperators/juno-ui-components";
+import BaseFooter from "./BaseComponents/BaseFooter";
 import { TransferType } from "../../../lib/constants";
 
 const TransferCancelModal = (props) => {
   const { commitment, title, startCommitmentTransfer, onModalClose } = props;
 
+  async function onConfirm() {
+    return startCommitmentTransfer(null, commitment, TransferType.NONE);
+  }
+
   return (
     <Modal
       title={title}
       open={true}
-      confirmButtonLabel="Confirm"
-      onConfirm={() => {
-        startCommitmentTransfer(null, commitment, TransferType.NONE);
-      }}
-      cancelButtonLabel="Cancel"
+      modalFooter={<BaseFooter onModalClose={onModalClose} guardFns={[]} actionFn={onConfirm} />}
       onCancel={() => {
         onModalClose();
       }}

--- a/src/components/commitment/Modals/TransferCancelModal.test.js
+++ b/src/components/commitment/Modals/TransferCancelModal.test.js
@@ -2,20 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components/index";
 import TransferCancelModal from "./TransferCancelModal";
+import { TransferType } from "../../../lib/constants";
 
 describe("TransferCancelModal", () => {
-  const mockProps = {
-    commitment: {
-      id: "commitment-123",
-      name: "Test Commitment",
-    },
-    title: "Transfer Commitment",
-    startCommitmentTransfer: jest.fn(),
-    onModalClose: jest.fn(),
-  };
+  let mockProps;
+
+  beforeEach(() => {
+    mockProps = {
+      commitment: {
+        id: "commitment-123",
+        name: "Test Commitment",
+      },
+      title: "Transfer Commitment",
+      startCommitmentTransfer: jest.fn().mockResolvedValue(undefined),
+      onModalClose: jest.fn(),
+    };
+  });
 
   test("should render the modal with the correct content", () => {
     render(
@@ -28,14 +33,16 @@ describe("TransferCancelModal", () => {
     expect(screen.getByText("Cancel")).toBeInTheDocument();
   });
 
-  test("should call the startCommitmentTransfer function when the confirm button is clicked", () => {
+  test("should call the startCommitmentTransfer function when the confirm button is clicked", async () => {
     render(
       <PortalProvider>
         <TransferCancelModal {...mockProps} />
       </PortalProvider>
     );
-    fireEvent.click(screen.getByText("Confirm"));
-    expect(mockProps.startCommitmentTransfer).toHaveBeenCalledWith(null, mockProps.commitment, "");
+    fireEvent.click(screen.getByTestId("modalConfirm"));
+    await waitFor(() => {
+      expect(mockProps.startCommitmentTransfer).toHaveBeenCalledWith(null, mockProps.commitment, TransferType.NONE);
+    });
   });
 
   test("should call the onModalClose function when the cancel button is clicked", () => {

--- a/src/components/commitment/Modals/TransferModal.js
+++ b/src/components/commitment/Modals/TransferModal.js
@@ -46,7 +46,7 @@ const TransferModal = (props) => {
     splitInputRef.current = e.target.value;
   }
 
-  function onConfirm() {
+  async function onConfirm() {
     if (splitCommitment) {
       const parsedInput = unit.parse(splitInputRef.current);
       if (parsedInput.error || parsedInput > commitment.amount || parsedInput <= 0) {
@@ -55,7 +55,7 @@ const TransferModal = (props) => {
       }
       commitment.amount = parsedInput;
     }
-    onTransfer(transferProject, commitment, publicationType);
+    return onTransfer(transferProject, commitment, publicationType);
   }
 
   return (

--- a/src/components/commitment/Modals/TransferModal.test.js
+++ b/src/components/commitment/Modals/TransferModal.test.js
@@ -42,7 +42,9 @@ describe("test transfer modal", () => {
     });
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).toHaveBeenCalled();
+    });
   });
 
   test("transfer split commitment with unit", async () => {
@@ -82,10 +84,15 @@ describe("test transfer modal", () => {
     fireEvent.change(splitInput, { target: { value: "1024" } });
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).not.toHaveBeenCalled();
+    // Wait for the async state to settle after the failed validation
+    await waitFor(() => {
+      expect(onTransfer).not.toHaveBeenCalled();
+    });
     fireEvent.change(splitInput, { target: { value: "1 GiB" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).toHaveBeenCalled();
+    });
   });
 
   test("transfer split commitment with non standard unit", async () => {
@@ -125,10 +132,15 @@ describe("test transfer modal", () => {
     fireEvent.change(splitInput, { target: { value: "1024 MiB" } });
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).not.toHaveBeenCalled();
+    // Wait for the async state to settle after the failed validation
+    await waitFor(() => {
+      expect(onTransfer).not.toHaveBeenCalled();
+    });
     fireEvent.change(splitInput, { target: { value: "1" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).toHaveBeenCalled();
+    });
   });
 
   test("Cluster/Domain level: transfer part of a commitment", async () => {
@@ -171,7 +183,9 @@ describe("test transfer modal", () => {
     fireEvent.change(splitInput, { target: { value: 5 } });
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).toHaveBeenCalled();
+    });
   });
 
   test("check marketplace options", async () => {
@@ -207,7 +221,9 @@ describe("test transfer modal", () => {
     expect(screen.queryByText(/marketplace/i)).not.toBeInTheDocument();
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).toHaveBeenCalled();
+    });
     unmountMoveAction();
 
     // Cluster/Domain level: Transfers to the marketplace, private transfers are performed using the move action.
@@ -237,7 +253,9 @@ describe("test transfer modal", () => {
     expect(screen.queryByText(/marketplace/i)).toBeInTheDocument();
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).toHaveBeenCalled();
+    });
     unmountMarketPlaceAction();
 
     // Project level: Contains the selection between private and public transfers.
@@ -270,7 +288,9 @@ describe("test transfer modal", () => {
     confirmInput = screen.getByTestId(/confirmInput/i);
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).toHaveBeenCalled();
+    });
 
     onTransfer = jest.fn((transferProject, commitment, publicationType) => {
       expect(publicationType).toEqual(TransferType.PUBLIC);
@@ -300,6 +320,8 @@ describe("test transfer modal", () => {
     fireEvent.click(marketplaceOption);
     fireEvent.change(confirmInput, { target: { value: "transfer" } });
     fireEvent.click(confirmButton);
-    expect(onTransfer).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onTransfer).toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/commitment/Modals/TransferReceiveModal.js
+++ b/src/components/commitment/Modals/TransferReceiveModal.js
@@ -72,10 +72,10 @@ const TransferReceiveModal = (props) => {
     setGetCommitment(true);
   }
 
-  function transferCommitmentByToken() {
+  async function transferCommitmentByToken() {
     // defense in depth - If button should be forcefully enabled.
     if (!commitment || !isCorrectResource) return;
-    transferCommitment(currentProject, commitment, tokenInput);
+    return transferCommitment(currentProject, commitment, tokenInput);
   }
 
   return (

--- a/src/components/commitment/Modals/TransferReceiveModal.test.js
+++ b/src/components/commitment/Modals/TransferReceiveModal.test.js
@@ -67,7 +67,9 @@ describe("test transfer receive modal", () => {
     const confirmInput = screen.getByTestId(/confirmInput/i);
     fireEvent.change(confirmInput, { target: { value: "receive" } });
     fireEvent.click(confirmButton);
-    expect(onReceive).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(onReceive).toHaveBeenCalled();
+    });
     const clearButton = screen.getByTestId("clearToken");
     fireEvent.click(clearButton);
     expect(screen.queryByText(/commitment found/i)).toBe(null);

--- a/src/components/commitment/Modals/UpdateDurationModal.js
+++ b/src/components/commitment/Modals/UpdateDurationModal.js
@@ -19,12 +19,12 @@ const UpdateDurationModal = (props) => {
   const durations = useCreateCommitmentStore((state) => state.validDurations);
   const validDurations = durations.get(commitment.id) || [];
 
-  function onConfirm() {
+  async function onConfirm() {
     if (!selectedDuration) {
       return;
     }
     const payload = { duration: selectedDuration };
-    onUpdate(commitment, payload);
+    return onUpdate(commitment, payload);
   }
 
   return (

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -144,29 +144,24 @@ const EditPanel = (props) => {
     return commitment?.transfer_status == TransferType.PUBLIC;
   }
 
-  function postCommitment(confirm_by = null, notifyOnConfirm = false) {
+  async function postCommitment(confirm_by = null, notifyOnConfirm = false) {
     const currentProjectID = currentProject?.metadata?.id;
     const currentDomainID = scope.isCluster() ? currentProject.metadata.domainID : null;
     setCommitmentIsLoading(true);
     const payload = confirm_by
       ? { ...newCommitment, id: "", confirm_by: confirm_by, notify_on_confirm: notifyOnConfirm }
       : { ...newCommitment, id: "" };
-    commit.mutate(
-      { payload: { commitment: payload }, queryKey: [currentProjectID, currentDomainID] },
-      {
-        onSuccess: () => {
-          setRefetchClusterAPI(true);
-          setRefetchDomainAPI(true);
-          setRefetchProjectAPI(true);
-          setRefetchCommitmentAPI(true);
-          setCommitmentIsLoading(false);
-        },
-        onError: (error) => {
-          setCommitmentIsLoading(false);
-          setToast(error.toString());
-        },
-      }
-    );
+    try {
+      await commit.mutateAsync({ payload: { commitment: payload }, queryKey: [currentProjectID, currentDomainID] });
+      setRefetchClusterAPI(true);
+      setRefetchDomainAPI(true);
+      setRefetchProjectAPI(true);
+      setRefetchCommitmentAPI(true);
+      setCommitmentIsLoading(false);
+    } catch (error) {
+      setCommitmentIsLoading(false);
+      setToast(error.toString());
+    }
     setCommitment(initialCommitmentObject);
     setIsSubmitting(false);
     setCanConfirm(null);
@@ -176,77 +171,67 @@ const EditPanel = (props) => {
   // Transferring a commitment requires to mark the commitment as transferrable and then transfer it to it's target.
   // Cluster and domain level transfer the commitment immediately after, except for marketplace postings or the cancellation of existing postings.
   // On project level we move between projects. First we initiate the transfer. On the target project we receive with the token input.
-  function startCommitmentTransfer(project, commitment, transferType = TransferType.UNLISTED) {
+  async function startCommitmentTransfer(project, commitment, transferType = TransferType.UNLISTED) {
     const mutation = scope.isCluster() ? startClusterTransfer : startTransfer;
     const sourceProjectID = currentProject?.metadata.id || null;
     const sourceDomainID = currentProject?.metadata.domainID || null;
     const shouldNotTransfer = transferType == TransferType.PUBLIC || transferType == TransferType.NONE;
 
-    mutation.mutate(
-      {
+    try {
+      const data = await mutation.mutateAsync({
         payload: { commitment: { amount: commitment.amount, transfer_status: transferType } },
         domainID: sourceDomainID,
         projectID: sourceProjectID,
         commitmentID: commitment.id,
-      },
-      {
-        onSuccess: (data) => {
-          // On Project level, the transfer start ends here. The transfer is handled with a separate request.
-          // On Cluster/Domain level, the transfer is only executed for private (unlisted) transfers.
-          if (scope.isProject() || shouldNotTransfer) {
-            resetCommitmentTransfer();
-            setRefetchProjectAPI(true);
-            setRefetchCommitmentAPI(true);
-            shouldNotTransfer && publicCommitmentQuery.refetch();
-            return;
-          }
-
-          // Proceed to transfer the commitment.
-          const receivedCommitment = data.commitment;
-          const transferToken = data.commitment.transfer_token;
-          transferCommitment(project, receivedCommitment, transferToken);
-        },
-        onError: (error) => {
-          resetCommitmentTransfer();
-          setToast(error.toString());
-        },
+      });
+      // On Project level, the transfer start ends here. The transfer is handled with a separate request.
+      // On Cluster/Domain level, the transfer is only executed for private (unlisted) transfers.
+      if (scope.isProject() || shouldNotTransfer) {
+        resetCommitmentTransfer();
+        setRefetchProjectAPI(true);
+        setRefetchCommitmentAPI(true);
+        shouldNotTransfer && publicCommitmentQuery.refetch();
+        return;
       }
-    );
+
+      // Proceed to transfer the commitment.
+      const receivedCommitment = data.commitment;
+      const transferToken = data.commitment.transfer_token;
+      await transferCommitment(project, receivedCommitment, transferToken);
+    } catch (error) {
+      resetCommitmentTransfer();
+      setToast(error.toString());
+    }
   }
 
-  function transferCommitment(project, commitment, transferToken) {
+  async function transferCommitment(project, commitment, transferToken) {
     // Cluster View targets the custom field domainID. It is set in the cluster project handling logic.
     const targetDomainID = project?.metadata.domainID || null;
     const targetProjectID = project.metadata.id;
 
-    transfer.mutate(
-      {
+    try {
+      await transfer.mutateAsync({
         domainID: targetDomainID,
         projectID: targetProjectID,
         commitmentID: commitment.id,
         transferToken: transferToken,
-      },
-      {
-        onSuccess: () => {
-          resetCommitmentTransfer();
-          setRefetchClusterAPI(true);
-          setRefetchDomainAPI(true);
-          setRefetchProjectAPI(true);
-          setRefetchCommitmentAPI(true);
-          setTransferProject(null);
-          publicCommitmentQuery.refetch();
-        },
-        onError: (error) => {
-          resetCommitmentTransfer();
-          setTransferProject(null);
-          setToast(error.toString());
-        },
-      }
-    );
+      });
+      resetCommitmentTransfer();
+      setRefetchClusterAPI(true);
+      setRefetchDomainAPI(true);
+      setRefetchProjectAPI(true);
+      setRefetchCommitmentAPI(true);
+      setTransferProject(null);
+      publicCommitmentQuery.refetch();
+    } catch (error) {
+      resetCommitmentTransfer();
+      setTransferProject(null);
+      setToast(error.toString());
+    }
   }
 
   // Delete commitment
-  function deleteCommitmentAPI(commitment) {
+  async function deleteCommitmentAPI(commitment) {
     if (!deleteCommitment) return;
     const mutation = scope.isCluster() ? clusterCommitmentDelete : commitmentDelete;
 
@@ -254,87 +239,77 @@ const EditPanel = (props) => {
     const targetDomainID = currentProject?.metadata.domainID || null;
     const targetProjectID = currentProject?.metadata.id || null;
 
-    mutation.mutate(
-      { domainID: targetDomainID, projectID: targetProjectID, commitmentID: commitment.id },
-      {
-        onSuccess: () => {
-          setRefetchClusterAPI(true);
-          setRefetchDomainAPI(true);
-          setRefetchProjectAPI(true);
-          setRefetchCommitmentAPI(true);
-          setDeleteCommitment(null);
-          isCommitmentPublic(commitment) && publicCommitmentQuery.refetch();
-        },
-        onError: (error) => {
-          setToast(error.toString());
-        },
-      }
-    );
+    try {
+      await mutation.mutateAsync({ domainID: targetDomainID, projectID: targetProjectID, commitmentID: commitment.id });
+      setRefetchClusterAPI(true);
+      setRefetchDomainAPI(true);
+      setRefetchProjectAPI(true);
+      setRefetchCommitmentAPI(true);
+      setDeleteCommitment(null);
+      isCommitmentPublic(commitment) && publicCommitmentQuery.refetch();
+    } catch (error) {
+      setToast(error.toString());
+    }
   }
 
   // Convert commitment
-  function convertCommitment(commitment, payload) {
+  async function convertCommitment(commitment, payload) {
     const targetDomainID = currentProject?.metadata.domainID || null;
     const targetProjectID = currentProject?.metadata.id || null;
 
-    convert.mutate(
-      { payload: payload, domainID: targetDomainID, projectID: targetProjectID, commitmentID: commitment.id },
-      {
-        onSuccess: () => {
-          setRefetchClusterAPI(true);
-          setRefetchDomainAPI(true);
-          setRefetchProjectAPI(true);
-          setRefetchCommitmentAPI(true);
-          setConversionCommitment(null);
-          isCommitmentPublic(commitment) && publicCommitmentQuery.refetch();
-        },
-        onError: (error) => {
-          setToast(error.toString());
-        },
-      }
-    );
+    try {
+      await convert.mutateAsync({
+        payload: payload,
+        domainID: targetDomainID,
+        projectID: targetProjectID,
+        commitmentID: commitment.id,
+      });
+      setRefetchClusterAPI(true);
+      setRefetchDomainAPI(true);
+      setRefetchProjectAPI(true);
+      setRefetchCommitmentAPI(true);
+      setConversionCommitment(null);
+      isCommitmentPublic(commitment) && publicCommitmentQuery.refetch();
+    } catch (error) {
+      setToast(error.toString());
+    }
   }
 
-  function updateCommitmentDuration(commitment, payload) {
+  async function updateCommitmentDuration(commitment, payload) {
     const targetDomainID = currentProject?.metadata.domainID || null;
     const targetProjectID = currentProject?.metadata.id || null;
 
-    updateDuration.mutate(
-      { payload: payload, domainID: targetDomainID, projectID: targetProjectID, commitmentID: commitment.id },
-      {
-        onSuccess: () => {
-          setRefetchClusterAPI(true);
-          setRefetchDomainAPI(true);
-          setRefetchProjectAPI(true);
-          setRefetchCommitmentAPI(true);
-          setUpdateDurationCommitment(null);
-          isCommitmentPublic(commitment) && publicCommitmentQuery.refetch();
-        },
-        onError: (error) => {
-          setToast(error.toString());
-        },
-      }
-    );
+    try {
+      await updateDuration.mutateAsync({
+        payload: payload,
+        domainID: targetDomainID,
+        projectID: targetProjectID,
+        commitmentID: commitment.id,
+      });
+      setRefetchClusterAPI(true);
+      setRefetchDomainAPI(true);
+      setRefetchProjectAPI(true);
+      setRefetchCommitmentAPI(true);
+      setUpdateDurationCommitment(null);
+      isCommitmentPublic(commitment) && publicCommitmentQuery.refetch();
+    } catch (error) {
+      setToast(error.toString());
+    }
   }
 
-  function mergeCommitments(payload) {
+  async function mergeCommitments(payload) {
     const targetDomainID = currentProject?.metadata.domainID || scope.domainID;
     const targetProjectID = currentProject?.metadata.id || scope.projectID;
-    merge.mutate(
-      { payload: payload, domainID: targetDomainID, projectID: targetProjectID },
-      {
-        onSuccess: () => {
-          setRefetchCommitmentAPI(true);
-          commitmentsToMerge.some((commitment) => isCommitmentPublic(commitment)) && publicCommitmentQuery.refetch();
-          setCommitmentsToMerge([]);
-          setConfirmMerge(false);
-          setIsMerging(false);
-        },
-        onError: (error) => {
-          setToast(error.toString());
-        },
-      }
-    );
+    try {
+      await merge.mutateAsync({ payload: payload, domainID: targetDomainID, projectID: targetProjectID });
+      setRefetchCommitmentAPI(true);
+      commitmentsToMerge.some((commitment) => isCommitmentPublic(commitment)) && publicCommitmentQuery.refetch();
+      setCommitmentsToMerge([]);
+      setConfirmMerge(false);
+      setIsMerging(false);
+    } catch (error) {
+      setToast(error.toString());
+    }
   }
 
   function onPostModalClose() {


### PR DESCRIPTION
The previous implementation was implemented in a fire and forget model, this PR implements an execution lock which awaits the API calls and prevents new clicks until the workflow is ready.
Because the modals use `BaseFooter` I implemented a check into its test file. I also tested the modals manually with a click macro.