### PR TITLE
update pnpm to 11.1.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -73,6 +73,14 @@
       "schedule": [
         "before 8am on Friday"
       ]
+    },
+    {
+      "matchPackageNames": ["msw"],
+      "postUpgradeTasks": {
+        "commands": ["npx msw init ./public --save"],
+        "fileFilters": ["public/mockServiceWorker.js"],
+        "executionMode": "update"
+      }
     }
   ],
   "semanticCommits": "disabled"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sapcc/limes-ui",
   "version": "1.17.0",
-  "packageManager": "pnpm@10.33.2",
+  "packageManager": "pnpm@11.1.0",
   "author": "VoigtS",
   "license": "Apache-2.0",
   "source": "src/index.js",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@parcel/watcher': true
+  cypress: true
+  esbuild: true
+  msw: true
+  unrs-resolver: true


### PR DESCRIPTION
pnpm v11 requires that dependency buildscripts are allowed explicitly.
I also want to try out a renovate `postUpgradeTask` for `msw`. Because mockdata is used for github pages I always want to update the `mockServiceWorker` with an incoming update