### PR TITLE
fix: preserve search filter on navigation

### DIFF
--- a/.changeset/fuzzy-mails-stop.md
+++ b/.changeset/fuzzy-mails-stop.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+fix: preserve category and resource filter when navigating to the editpanel or any subroutes

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -53,7 +53,7 @@ const Overview = (props) => {
   // Hitting edit view URL without edit permissions should lead to the main route.
   React.useEffect(() => {
     if (canEdit || location.pathname === `/${currentArea}`) return;
-    navigate(`/${currentArea}`);
+    navigate({ pathname: `/${currentArea}`, search: location.search});
   }, [location.pathname, currentArea, canEdit]);
 
   // navigate to the selected area while also resetting the resource filter

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -53,7 +53,7 @@ const Overview = (props) => {
   // Hitting edit view URL without edit permissions should lead to the main route.
   React.useEffect(() => {
     if (canEdit || location.pathname === `/${currentArea}`) return;
-    navigate({ pathname: `/${currentArea}`, search: location.search});
+    navigate({ pathname: `/${currentArea}`, search: location.search });
   }, [location.pathname, currentArea, canEdit]);
 
   // navigate to the selected area while also resetting the resource filter

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -6,7 +6,7 @@ import { useGlobalStore, useCreateCommitmentStore } from "../StoreProvider";
 import { t } from "../../lib/utils";
 import { CustomZones, PanelType } from "../../lib/constants";
 import { Button, Icon, Pill, Stack } from "@cloudoperators/juno-ui-components";
-import { Link } from "react-router";
+import { Link, useLocation } from "react-router";
 import { ProjectBadges } from "../shared/LimesBadges";
 import { isAZUnaware, getResourceDurations } from "../../lib/utils";
 import ResourceBarBuilder from "../resourceBar/ResourceBarBuilder";
@@ -91,6 +91,7 @@ const Resource = (props) => {
   const isEditing = useCreateCommitmentStore((state) => state.isEditing);
   const { resetCommitment } = useResetCommitment();
   const [displayResourceInfo, setDisplayResourceInfo] = React.useState(false);
+  const location = useLocation();
 
   const forbidAutogrowthForwardProps = {
     editMode: canEdit,
@@ -157,7 +158,10 @@ const Resource = (props) => {
         {canEdit && !isPanelView && (
           <Stack className="items-center" gap="1">
             {editableResource && (
-              <Link to={`/${props.area}/edit/${categoryName}/${props.resource.name}`} state={props}>
+              <Link
+                to={{ pathname: `/${props.area}/edit/${categoryName}/${props.resource.name}`, search: location.search }}
+                state={props}
+              >
                 <Button
                   data-cy={`edit/${props.resource.name}`}
                   data-testid={`edit/${props.resource.name}`}
@@ -170,7 +174,10 @@ const Resource = (props) => {
             )}
             {!scope.isProject() && tracksQuota && (
               <Link
-                to={`/${props.area}/edit/${categoryName}/${props.resource.name}/${PanelType.quota.name}`}
+                to={{
+                  pathname: `/${props.area}/edit/${categoryName}/${props.resource.name}/${PanelType.quota.name}`,
+                  search: location.search,
+                }}
                 state={props}
               >
                 <Button data-testid={"setMaxQuotaPanel"} size="small" icon="edit">

--- a/src/components/mainView/Resource.test.js
+++ b/src/components/mainView/Resource.test.js
@@ -4,7 +4,7 @@
 import React from "react";
 import Resource from "./Resource";
 import { Scope } from "../../lib/scope";
-import { MemoryRouter } from "react-router";
+import { MemoryRouter, useLocation } from "react-router";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import { act, renderHook, screen, waitFor } from "@testing-library/react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
@@ -23,6 +23,54 @@ queryClient.setQueryDefaults(["maxQuota"], {
 });
 
 describe("Resource tests", () => {
+  test("edit link preserves search params", async () => {
+    const scope = new Scope({ projectID: "123", domainID: "456" });
+    const res = {
+      name: "testResource",
+      editableResource: true,
+      per_az: [{ name: "az1", projects_usage: 10 }],
+    };
+    const forwardProps = {
+      area: "testArea",
+      canEdit: true,
+      categoryName: "testCategory",
+      serviceType: "testService",
+    };
+
+    const initialEntries = ["/testArea?search=myfilter&category=compute"];
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={initialEntries}>
+              <Resource key={res.name} resource={res} {...forwardProps} tracksQuota={true} />
+              {children}
+            </MemoryRouter>
+          </QueryClientProvider>
+        </StoreProvider>
+      </PortalProvider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+        location: useLocation(),
+      }),
+      { wrapper }
+    );
+
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+    });
+
+    const editLink = screen.getByTestId("edit/testResource").closest("a");
+    expect(editLink).toHaveAttribute(
+      "href",
+      "/testArea/edit/testCategory/testResource?search=myfilter&category=compute"
+    );
+  });
+
   test("display correct edit option for resource", async () => {
     let scope = new Scope({ projectID: "123", domainID: "456" });
     const res = {

--- a/src/components/panel/EditPanel.test.js
+++ b/src/components/panel/EditPanel.test.js
@@ -7,6 +7,7 @@ import moment from "moment";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, fireEvent, renderHook, screen, waitFor } from "@testing-library/react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
+import { MemoryRouter } from "react-router";
 import { Scope } from "../../lib/scope";
 import StoreProvider, {
   globalStoreActions,
@@ -108,14 +109,16 @@ describe("EditPanel tests", () => {
     resource.per_az.commitmentSum = 10;
 
     const wrapper = ({ children }) => (
-      <PortalProvider>
-        <StoreProvider>
-          <QueryClientProvider client={queryClient}>
-            <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
-            {children}
-          </QueryClientProvider>
-        </StoreProvider>
-      </PortalProvider>
+      <MemoryRouter>
+        <PortalProvider>
+          <StoreProvider>
+            <QueryClientProvider client={queryClient}>
+              <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
+              {children}
+            </QueryClientProvider>
+          </StoreProvider>
+        </PortalProvider>
+      </MemoryRouter>
     );
     const { result } = renderHook(
       () => ({
@@ -152,14 +155,16 @@ describe("EditPanel tests", () => {
       per_az: [{ name: "az_1", projects_usage: 10, quota: 20 }],
     };
     const wrapper = ({ children }) => (
-      <PortalProvider>
-        <StoreProvider>
-          <QueryClientProvider client={queryClient}>
-            <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
-            {children}
-          </QueryClientProvider>
-        </StoreProvider>
-      </PortalProvider>
+      <MemoryRouter>
+        <PortalProvider>
+          <StoreProvider>
+            <QueryClientProvider client={queryClient}>
+              <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
+              {children}
+            </QueryClientProvider>
+          </StoreProvider>
+        </PortalProvider>
+      </MemoryRouter>
     );
     const { result, rerender } = renderHook(
       () => ({
@@ -282,14 +287,16 @@ describe("EditPanel tests", () => {
     resource.per_az.commitmentSum = 10;
 
     const wrapper = ({ children }) => (
-      <PortalProvider>
-        <StoreProvider>
-          <QueryClientProvider client={queryClient}>
-            <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
-            {children}
-          </QueryClientProvider>
-        </StoreProvider>
-      </PortalProvider>
+      <MemoryRouter>
+        <PortalProvider>
+          <StoreProvider>
+            <QueryClientProvider client={queryClient}>
+              <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
+              {children}
+            </QueryClientProvider>
+          </StoreProvider>
+        </PortalProvider>
+      </MemoryRouter>
     );
     const { result } = renderHook(
       () => ({
@@ -353,14 +360,16 @@ describe("EditPanel tests", () => {
     };
 
     const wrapper = ({ children }) => (
-      <PortalProvider>
-        <StoreProvider>
-          <QueryClientProvider client={queryClient}>
-            <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
-            {children}
-          </QueryClientProvider>
-        </StoreProvider>
-      </PortalProvider>
+      <MemoryRouter>
+        <PortalProvider>
+          <StoreProvider>
+            <QueryClientProvider client={queryClient}>
+              <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
+              {children}
+            </QueryClientProvider>
+          </StoreProvider>
+        </PortalProvider>
+      </MemoryRouter>
     );
 
     const { result, rerender } = renderHook(
@@ -436,14 +445,16 @@ describe("EditPanel tests", () => {
     };
     resource.per_az.commitmentSum = 10;
     const wrapper = ({ children }) => (
-      <PortalProvider>
-        <StoreProvider>
-          <QueryClientProvider client={queryClient}>
-            <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
-            {children}
-          </QueryClientProvider>
-        </StoreProvider>
-      </PortalProvider>
+      <MemoryRouter>
+        <PortalProvider>
+          <StoreProvider>
+            <QueryClientProvider client={queryClient}>
+              <EditPanel serviceType="testService" currentResource={resource} tracksQuota={true} />
+              {children}
+            </QueryClientProvider>
+          </StoreProvider>
+        </PortalProvider>
+      </MemoryRouter>
     );
     const { result, rerender } = renderHook(
       () => ({

--- a/src/components/panel/PanelManager.js
+++ b/src/components/panel/PanelManager.js
@@ -5,7 +5,7 @@ import React from "react";
 import { Panel } from "@cloudoperators/juno-ui-components";
 import EditPanel from "./EditPanel";
 import { tracksQuota } from "../../lib/utils";
-import { useParams, useNavigate } from "react-router";
+import { useParams, useNavigate, useLocation } from "react-router";
 import { t, getCurrentResource } from "../../lib/utils";
 import { initialCommitmentObject, PanelType } from "../../lib/constants";
 import { createCommitmentStoreActions, useCreateCommitmentStore } from "../StoreProvider";
@@ -17,6 +17,7 @@ const validSubRoutes = Object.values(PanelType).map((type) => type.name);
 const PanelManager = (props) => {
   const params = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const { currentArea, categoryName, resourceName, subRoute: rawSubRoute } = { ...params };
   // Validate subRoute - only allow valid panel types, treat invalid values as undefined
   const subRoute = rawSubRoute && validSubRoutes.includes(rawSubRoute) ? rawSubRoute : undefined;
@@ -74,7 +75,7 @@ const PanelManager = (props) => {
       opened={isEditing}
       onClose={() => {
         onPanelClose();
-        navigate(`/${currentArea}`);
+        navigate({ pathname: `/${currentArea}`, search: location.search });
       }}
       closeable={true}
       heading={`Manage Committed Resources: ${t(categoryName)} - ${t(resourceName)}`}


### PR DESCRIPTION
Noticed in QA. When the user navigates to the edit panel or a subroute, the overview filter settings shall be preserved.
I included a test in the resource test file, the Editpanel tests needed to be adjusted, because due to the usage of `useLocation`, we need a router context.