### PR TITLE
workflows: add explicit permission rules

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,6 +6,11 @@ on:
     types: [closed]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+
+permissions:
+  contents: read # Checkout the repo
+  packages: write # Publish npm package to GitHub Packages
+
 jobs:
   build-and-publish:
     if: ${{ contains(github.head_ref, 'changeset-release') && github.event.pull_request.merged == true }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions:
+  contents: write # Push commits to the changeset branch
+  pull-requests: write # Create/update the release PR
+
 jobs:
   release:
     name: Release


### PR DESCRIPTION
The org hardened the Repo settings, this PR adds missing `GITHUB_TOKEN` permission rules.