### PR TITLE
Calendar: fix UTC conversion for UTC- timezones

### DIFF
--- a/.changeset/purple-moose-build.md
+++ b/.changeset/purple-moose-build.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+fix: DayPicker now ensures a stable midnight UTC timestamp in UTC- regions

--- a/src/components/commitment/CommitmentCalendar.js
+++ b/src/components/commitment/CommitmentCalendar.js
@@ -57,8 +57,11 @@ const CommitmentCalendar = (props) => {
           currentDayCommit(false);
         }
 
-        // Timestamp needs to match server time in UTC.
-        pickedDate.setHours(pickedDate.getHours() + Math.abs(pickedDate.getTimezoneOffset() / 60));
+        // Convert the selected calendar date to UTC (00:00:00 UTC on that date).
+        const year = pickedDate.getFullYear();
+        const month = pickedDate.getMonth();
+        const day = pickedDate.getDate();
+        pickedDate.setTime(Date.UTC(year, month, day, 0, 0, 0, 0));
 
         setSelectedDate(pickedDate);
       }}

--- a/src/components/commitment/CommitmentCalendar.test.js
+++ b/src/components/commitment/CommitmentCalendar.test.js
@@ -66,7 +66,7 @@ describe("test Commitment Calendar", () => {
     const startDate = moment.utc(0).startOf("day");
     const targetDate = startDate.clone().add(2, "days");
     Date.now = jest.fn(() => startDate.valueOf());
-    
+
     let capturedDate = null;
     render(
       <CommitmentCalendar

--- a/src/components/commitment/CommitmentCalendar.test.js
+++ b/src/components/commitment/CommitmentCalendar.test.js
@@ -55,4 +55,34 @@ describe("test Commitment Calendar", () => {
     fireEvent.click(selectedDate);
     expect(screen.queryByText(/Selected date must be today or in the future/i)).not.toBe(null);
   });
+
+  test("selected date should be midnight UTC regardless of timezone", () => {
+    const originalGetTimezoneOffset = Date.prototype.getTimezoneOffset;
+
+    // Simulate UTC-5 timezone
+    Date.prototype.getTimezoneOffset = jest.fn(() => 300);
+
+    // Use Unix epoch as start date (1970-01-01)
+    const startDate = moment.utc(0).startOf("day");
+    const targetDate = startDate.clone().add(2, "days");
+    Date.now = jest.fn(() => startDate.valueOf());
+    
+    let capturedDate = null;
+    render(
+      <CommitmentCalendar
+        startDate={startDate.toDate()}
+        selectedDate={null}
+        setSelectedDate={(date) => (capturedDate = date)}
+        currentDayCommit={() => {}}
+      />
+    );
+
+    // Click on the target date (Saturday, January 3rd, 1970)
+    const targetDateLabel = targetDate.format("dddd, MMMM Do, YYYY");
+    fireEvent.click(screen.getByLabelText(new RegExp(targetDateLabel, "i")));
+
+    expect(capturedDate).not.toBeNull();
+    expect(capturedDate.toISOString()).toBe("1970-01-03T00:00:00.000Z");
+    Date.prototype.getTimezoneOffset = originalGetTimezoneOffset;
+  });
 });


### PR DESCRIPTION
The previous implementation worked fine for UTC+X timezones, but was inaccurate for UTC-X timezones.
The reason is that the offset was always added to the timestamp.
This is now fixed by guaranteeing a hard time set to midnight UTC for manually selected dates that are future dated.