### PR TITLE
adjust UI permission ruleset

### DIFF
--- a/.changeset/cyan-trams-eat.md
+++ b/.changeset/cyan-trams-eat.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": minor
+---
+
+Enable EditPanel for UI viewers, non-view actions are disabled in this case

--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ const App = (props = {}) => {
   const { setGlobalAPI } = apiStoreActions();
   const { setToken } = apiStoreActions();
   const token = useApiStore((state) => state.globalAPI.token);
-  const { setScope } = globalStoreActions();
+  const { setScope, setCanEdit } = globalStoreActions();
   const projectID = useApiStore((state) => state.globalAPI.projectID);
   const apiReady = useApiStore((state) => state.globalAPI.apiReady);
   const [tokenError, setTokenError] = React.useState(false);
@@ -33,6 +33,7 @@ const App = (props = {}) => {
       domainID: props.domainID || "",
     });
     setScope(scope);
+    setCanEdit(props.canEdit);
   }, []);
 
   // Reload page after token timeout.

--- a/src/components/commitment/Marketplace.test.js
+++ b/src/components/commitment/Marketplace.test.js
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, renderHook, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Scope } from "../../lib/scope";
-import StoreProvider from "../StoreProvider";
+import StoreProvider, { globalStoreActions } from "../StoreProvider";
 import Marketplace from "./Marketplace";
 import { PortalProvider } from "@cloudoperators/juno-ui-components/index";
 
@@ -150,5 +150,61 @@ describe("Marketplace tests", () => {
       expect(screen.queryByText("Transferring")).not.toBe(null);
       expect(screen.queryByText("Convert")).toBe(null);
     });
+  });
+
+  test("marketplace actions should be active depending on the canEdit state", async () => {
+    const commitments = [...base];
+    const publicCommitments = [...commitments];
+    publicCommitments.push({
+      id: "commitment-3",
+      amount: 3,
+      availability_zone: "az_3",
+      duration: "3 years",
+    });
+
+    const publicCommitmentQuery = {
+      data: { commitments: publicCommitments },
+      isLoading: false,
+      isError: false,
+      error: null,
+    };
+
+    const wrapper = ({ children }) => (
+      <StoreProvider>
+        <PortalProvider>
+          <Marketplace
+            scope={new Scope({ projectID: "123", domainID: "456" })}
+            projectCommitments={commitments}
+            publicCommitmentQuery={publicCommitmentQuery}
+            transferCommitment={jest.fn()}
+          />
+          {children}
+        </PortalProvider>
+      </StoreProvider>
+    );
+
+    const { result, rerender } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+
+    // Set canEdit to true - buttons should be enabled (positive test)
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+    const cancelButtons = screen.getAllByTestId("mp-cancel");
+    const receiveButtons = screen.getAllByTestId("mp-receive");
+    expect(cancelButtons[0]).toBeEnabled();
+    expect(receiveButtons[0]).toBeEnabled();
+
+    // Marketplace action buttons should be disabled when canEdit is false (viewer role).
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(false);
+    });
+    expect(cancelButtons[0]).toBeDisabled();
+    expect(receiveButtons[0]).toBeDisabled();
   });
 });

--- a/src/components/commitment/MarketplaceActions.js
+++ b/src/components/commitment/MarketplaceActions.js
@@ -4,7 +4,7 @@
 import React from "react";
 import { TransferStatus } from "../../lib/constants";
 import { Button, Icon, Stack } from "@cloudoperators/juno-ui-components/index";
-import { createCommitmentStoreActions } from "../StoreProvider";
+import { createCommitmentStoreActions, useGlobalStore } from "../StoreProvider";
 import Actions from "./Operations/Actions";
 import ToolTipWrapper from "../shared/ToolTipWrapper";
 import useCommitmentFilter from "../../hooks/useCommitmentFilter";
@@ -17,6 +17,7 @@ const MarketplaceActions = (props) => {
   const { getCommitmentLabel } = useCommitmentFilter();
   const { setTransferredCommitment } = createCommitmentStoreActions();
   const { setTransferFromAndToProject } = createCommitmentStoreActions();
+  const canEdit = useGlobalStore((state) => state.canEdit);
   const projectOwnsCommitment = projectCommitments.some((pc) => pc.id == commitment.id);
 
   if (scope.isCluster()) {
@@ -31,12 +32,17 @@ const MarketplaceActions = (props) => {
         icon="download"
         size="small"
         title="Receive"
-        onClick={() => setShowModal(true)}
+        disabled={!canEdit}
+        onClick={() => {
+          if (!canEdit) return;
+          setShowModal(true);
+        }}
       />
     );
   }
 
   function cancelCommitmentTransfer() {
+    if (!canEdit) return;
     setTransferFromAndToProject(TransferStatus.CANCEL);
     setTransferredCommitment(commitment);
   }
@@ -61,6 +67,7 @@ const MarketplaceActions = (props) => {
           {projectOwnsCommitment ? (
             <Button
               data-testid="mp-cancel"
+              disabled={!canEdit}
               onClick={() => {
                 cancelCommitmentTransfer();
               }}

--- a/src/components/commitment/Operations/Actions.test.js
+++ b/src/components/commitment/Operations/Actions.test.js
@@ -27,15 +27,22 @@ describe("test Action Operation", () => {
       </PortalProvider>
     );
 
-    renderHook(
+    const { result, rerender } = renderHook(
       () => ({
         commitmentStore: useCreateCommitmentStore(),
         commitmentStoreActions: createCommitmentStoreActions(),
+        globalStoreActions: globalStoreActions(),
       }),
       {
         wrapper,
       }
     );
+
+    // Set canEdit to true to enable the action
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+
     expect(screen.queryByText(/committed/i)).not.toBe(null);
     const contextMenu = await waitFor(() => {
       return screen.getByTitle(/more/i);
@@ -43,6 +50,17 @@ describe("test Action Operation", () => {
     userEvent.click(contextMenu);
     await waitFor(() => {
       expect(screen.queryByText("Delete")).not.toBe(null);
+    });
+
+    // Menu items should be disabled when canEdit is false (viewer role).
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(false);
+    });
+    userEvent.click(contextMenu);
+    await waitFor(() => {
+      const deleteMenuItem = screen.getByText("Delete").closest('[role="menuitem"]');
+      expect(deleteMenuItem).toHaveAttribute("aria-disabled", "true");
     });
   });
 
@@ -57,10 +75,11 @@ describe("test Action Operation", () => {
         </StoreProvider>
       </PortalProvider>
     );
-    const { result } = renderHook(
+    const { result, rerender } = renderHook(
       () => ({
         commitmentStore: useCreateCommitmentStore(),
         commitmentStoreActions: createCommitmentStoreActions(),
+        globalStoreActions: globalStoreActions(),
       }),
       {
         wrapper,
@@ -68,6 +87,7 @@ describe("test Action Operation", () => {
     );
     act(() => {
       result.current.commitmentStoreActions.setShowConversionOption(true);
+      result.current.globalStoreActions.setCanEdit(true);
     });
     const contextMenu = await waitFor(() => {
       return screen.getByTitle(/more/i);
@@ -75,6 +95,17 @@ describe("test Action Operation", () => {
     await waitFor(() => {
       userEvent.click(contextMenu);
       expect(screen.queryByText(/convert/i)).not.toBe(null);
+    });
+
+    // Menu items should be disabled when canEdit is false (viewer role).
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(false);
+    });
+    userEvent.click(contextMenu);
+    await waitFor(() => {
+      const convertMenuItem = screen.getByText(/convert/i).closest('[role="menuitem"]');
+      expect(convertMenuItem).toHaveAttribute("aria-disabled", "true");
     });
   });
 
@@ -102,6 +133,7 @@ describe("test Action Operation", () => {
     );
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
     });
 
     const contextMenu = await waitFor(() => {
@@ -117,11 +149,25 @@ describe("test Action Operation", () => {
     commitment.transfer_status = "public";
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
     });
     userEvent.click(contextMenu);
     await waitFor(() => {
       expect(screen.queryByText(/transferring/i)).not.toBe(null);
       expect(screen.queryByText(/cancel transfer/i)).not.toBe(null);
+    });
+
+    // Menu items should be disabled when canEdit is false (viewer role).
+    rerender();
+    delete commitment.transfer_status;
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(false);
+    });
+    userEvent.click(contextMenu);
+    await waitFor(() => {
+      const transferMenuItem = screen.getByText(/^transfer$/i).closest('[role="menuitem"]');
+      expect(transferMenuItem).toHaveAttribute("aria-disabled", "true");
     });
   });
   test("should remove cancel transfer action when transfer completes", async () => {
@@ -150,6 +196,7 @@ describe("test Action Operation", () => {
     );
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
     });
 
     const contextMenu = await waitFor(() => {
@@ -169,6 +216,7 @@ describe("test Action Operation", () => {
     rerender();
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
     });
 
     // Verify cancel transfer is removed
@@ -193,21 +241,39 @@ describe("test Action Operation", () => {
         </StoreProvider>
       </PortalProvider>
     );
-    renderHook(
+    const { result, rerender } = renderHook(
       () => ({
         commitmentStore: useCreateCommitmentStore(),
         commitmentStoreActions: createCommitmentStoreActions(),
+        globalStoreActions: globalStoreActions(),
       }),
       {
         wrapper,
       }
     );
+
+    // Set canEdit to true to enable the action
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+
     const contextMenu = await waitFor(() => {
       return screen.getByTitle(/more/i);
     });
     userEvent.click(contextMenu);
     await waitFor(() => {
       expect(screen.queryByText(/edit/i)).not.toBe(null);
+    });
+
+    // Menu items should be disabled when canEdit is false (viewer role).
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(false);
+    });
+    userEvent.click(contextMenu);
+    await waitFor(() => {
+      const editMenuItem = screen.getByText(/edit/i).closest('[role="menuitem"]');
+      expect(editMenuItem).toHaveAttribute("aria-disabled", "true");
     });
   });
 });

--- a/src/components/commitment/Operations/MenuItemBuilder.js
+++ b/src/components/commitment/Operations/MenuItemBuilder.js
@@ -3,16 +3,21 @@
 
 import React from "react";
 import { PopupMenuItem } from "@cloudoperators/juno-ui-components/index";
+import { useGlobalStore } from "../../StoreProvider";
+
 const MenuItemBuilder = (props) => {
   const { icon, text, callBack } = props;
+  const canEdit = useGlobalStore((state) => state.canEdit);
 
   return (
     <PopupMenuItem
       onClick={() => {
+        if (!canEdit) return;
         callBack();
       }}
       icon={icon}
       label={text}
+      disabled={!canEdit}
     ></PopupMenuItem>
   );
 };

--- a/src/components/commitmentRenewal/RenewalManager.js
+++ b/src/components/commitmentRenewal/RenewalManager.js
@@ -5,14 +5,14 @@ import React from "react";
 import CommitmentRenewal from "./CommitmentRenewal";
 import moment from "moment";
 import { parseCommitmentDuration } from "../../lib/parseCommitmentDurations";
-import { useProjectStore } from "../StoreProvider";
+import { useProjectStore, useGlobalStore } from "../StoreProvider";
 import useCommitmentFilter from "../../hooks/useCommitmentFilter";
 import { ErrorBoundary } from "../../lib/ErrorBoundary";
 
 // RenewalManager fetches renwable commitments for the current scope.
 // Currently only available at project level.
-const RenewalManager = (props) => {
-  const { canEdit = false } = props;
+const RenewalManager = () => {
+  const canEdit = useGlobalStore((state) => state.canEdit);
   const commitments = useProjectStore((state) => state.commitments);
   const { isActive, getCommitmentLabel } = useCommitmentFilter();
   const now = moment().utc();

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -16,7 +16,7 @@ import OverviewFilter from "./overviewFilter/OverviewFilter";
 import useOverviewFilters from "./overviewFilter/useOverviewFilters";
 
 const Overview = (props) => {
-  const { overview, categories, canEdit } = props;
+  const { overview, categories } = props;
   const scope = useGlobalStore((state) => state.scope);
   const isEditing = useCreateCommitmentStore((state) => state.isEditing);
   const navigate = useNavigate();
@@ -50,11 +50,6 @@ const Overview = (props) => {
     }
   }, [selectedArea, currentArea]);
 
-  // Hitting edit view URL without edit permissions should lead to the main route.
-  React.useEffect(() => {
-    if (canEdit || location.pathname === `/${currentArea}`) return;
-    navigate({ pathname: `/${currentArea}`, search: location.search });
-  }, [location.pathname, currentArea, canEdit]);
 
   // navigate to the selected area while also resetting the resource filter
   function onTabChange(selectedArea) {
@@ -117,8 +112,8 @@ const Overview = (props) => {
     );
   }
 
-  function renderRenewal(canEdit) {
-    return <RenewalManager canEdit={canEdit} />;
+  function renderRenewal() {
+    return <RenewalManager />;
   }
 
   let currentTab;
@@ -127,7 +122,7 @@ const Overview = (props) => {
       currentTab = renderPAYG();
       break;
     case COMMITMENTRENEWALKEY:
-      currentTab = renderRenewal(canEdit);
+      currentTab = renderRenewal();
       break;
     default:
       currentTab = renderArea();
@@ -176,7 +171,7 @@ const Overview = (props) => {
         />
       )}
       {currentTab}
-      {canEdit && <Outlet />}
+      <Outlet />
     </Container>
   );
 };

--- a/src/components/mainView/Overview.js
+++ b/src/components/mainView/Overview.js
@@ -50,7 +50,6 @@ const Overview = (props) => {
     }
   }, [selectedArea, currentArea]);
 
-
   // navigate to the selected area while also resetting the resource filter
   function onTabChange(selectedArea) {
     navigate(`/${selectedArea}`, { replace: false });

--- a/src/components/mainView/Overview.test.js
+++ b/src/components/mainView/Overview.test.js
@@ -131,10 +131,13 @@ describe("Overview", () => {
     expect(screen.getByText("area-1")).toHaveAttribute("aria-selected", "true");
   });
 
-  test("calling the panel URL with no edit permissions reroutes to the default route", async () => {
+  test("calling the panel URL with no edit permissions still shows the panel (actions are disabled)", async () => {
+    // The panel is always visible regardless of canEdit
+    // The actions inside the panel are disabled when canEdit is false
     renderOverview("/area-1/edit/some/stuff", false);
     await waitFor(() => {
-      expect(window.location.hash).toEqual("#/area-1");
+      // Manually editing the URL should not cause a route redirect to another URL.
+      expect(window.location.hash).toEqual("#/area-1/edit/some/stuff");
     });
   });
 });
@@ -175,6 +178,7 @@ test("displays specialUnitInfo", () => {
     },
   };
 
+  window.location.hash = "/area-1";
   render(
     <StoreProvider>
       <PortalProvider>
@@ -186,7 +190,6 @@ test("displays specialUnitInfo", () => {
                 <Overview
                   overview={mockOverviewWithHwVersion}
                   categories={mockCategoriesWithHwVersion}
-                  canEdit={true}
                 />
               }
             />

--- a/src/components/mainView/Overview.test.js
+++ b/src/components/mainView/Overview.test.js
@@ -186,12 +186,7 @@ test("displays specialUnitInfo", () => {
           <Routes>
             <Route
               path="/:currentArea?"
-              element={
-                <Overview
-                  overview={mockOverviewWithHwVersion}
-                  categories={mockCategoriesWithHwVersion}
-                />
-              }
+              element={<Overview overview={mockOverviewWithHwVersion} categories={mockCategoriesWithHwVersion} />}
             />
           </Routes>
         </HashRouter>

--- a/src/components/mainView/Resource.js
+++ b/src/components/mainView/Resource.js
@@ -155,7 +155,7 @@ const Resource = (props) => {
             )}
           </Stack>
         </Stack>
-        {canEdit && !isPanelView && (
+        {!isPanelView && (
           <Stack className="items-center" gap="1">
             {editableResource && (
               <Link

--- a/src/components/panel/EditPanel.test.js
+++ b/src/components/panel/EditPanel.test.js
@@ -193,6 +193,7 @@ describe("EditPanel tests", () => {
     ];
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
       result.current.projectStoreActions.setCommitments(commitments);
     });
     const addCommitment1 = screen.getByTestId("addCommitment");
@@ -212,6 +213,7 @@ describe("EditPanel tests", () => {
     rerender();
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
       result.current.projectStoreActions.setCommitments([]);
     });
 
@@ -233,9 +235,20 @@ describe("EditPanel tests", () => {
     rerender();
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
       result.current.projectStoreActions.setCommitments(commitments);
     });
     expect(screen.queryByTestId("addCommitment")).not.toBeInTheDocument();
+
+    // Add commitment button should be disabled when canEdit is false (viewer role).
+    resource.commitment_config = { durations: ["1 year", "3 years"] };
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(false);
+      result.current.projectStoreActions.setCommitments(commitments);
+    });
+    expect(screen.getByTestId("addCommitment")).toBeDisabled();
   });
 
   test("Commitment merging", async () => {
@@ -298,7 +311,7 @@ describe("EditPanel tests", () => {
         </PortalProvider>
       </MemoryRouter>
     );
-    const { result } = renderHook(
+    const { result, rerender } = renderHook(
       () => ({
         globalStoreActions: globalStoreActions(),
         projectStoreActions: projectStoreActions(),
@@ -311,6 +324,7 @@ describe("EditPanel tests", () => {
     );
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
       result.current.projectStoreActions.setCommitments(commitments);
     });
 
@@ -345,6 +359,16 @@ describe("EditPanel tests", () => {
     fireEvent.click(mergeAction);
     expect(screen.getByTestId("mergeModal")).toBeInTheDocument();
     expect(screen.getByText("3 MiB")).toBeInTheDocument();
+
+    // Merge buttons should be disabled when canEdit is false (viewer role).
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(false);
+      result.current.projectStoreActions.setCommitments(commitments);
+    });
+    expect(screen.getByTestId("mergeToggle")).toBeDisabled();
+    expect(screen.getByTestId("mergeAction")).toBeDisabled();
   });
 
   test("panelNavDisabled: tabs enabled at project level, disabled at domain level until projects load", async () => {

--- a/src/components/panel/ReceiveCommitment.js
+++ b/src/components/panel/ReceiveCommitment.js
@@ -3,19 +3,22 @@
 
 import React from "react";
 import { Button, Icon } from "@cloudoperators/juno-ui-components";
-import { createCommitmentStoreActions } from "../StoreProvider";
+import { createCommitmentStoreActions, useGlobalStore } from "../StoreProvider";
 import { TransferStatus } from "../../lib/constants";
 
 const ReceiveCommitment = () => {
   const { setTransferFromAndToProject } = createCommitmentStoreActions();
+  const canEdit = useGlobalStore((state) => state.canEdit);
 
   function onTransfer() {
+    if (!canEdit) return;
     setTransferFromAndToProject(TransferStatus.RECEIVE);
   }
 
   return (
     <Button
       size="small"
+      disabled={!canEdit}
       onClick={() => {
         onTransfer();
       }}

--- a/src/components/panel/ReceiveCommitment.test.js
+++ b/src/components/panel/ReceiveCommitment.test.js
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+import React from "react";
+import { act, renderHook, screen } from "@testing-library/react";
+import { PortalProvider } from "@cloudoperators/juno-ui-components";
+import StoreProvider, { globalStoreActions } from "../StoreProvider";
+import ReceiveCommitment from "./ReceiveCommitment";
+
+describe("ReceiveCommitment tests", () => {
+  test("Receive button should be enabled when the canEdit state is true", async () => {
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <ReceiveCommitment />
+          {children}
+        </StoreProvider>
+      </PortalProvider>
+    );
+
+    const { result, rerender } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+
+    // Set canEdit to true - button should be enabled (positive test)
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+    const receiveButton = screen.getByRole("button", { name: /receive/i });
+    expect(receiveButton).toBeEnabled();
+
+    // Receive button should be disabled when canEdit is false (viewer role).
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(false);
+    });
+    expect(receiveButton).toBeDisabled();
+  });
+});

--- a/src/components/project/ProjectQuotaDetails.test.js
+++ b/src/components/project/ProjectQuotaDetails.test.js
@@ -42,6 +42,7 @@ describe("test project quota details", () => {
     );
     act(() => {
       result.current.globalStoreActions.setScope(scope);
+      result.current.globalStoreActions.setCanEdit(true);
     });
     expect(screen.queryByText(/not set/i)).not.toBe(null);
     expect(screen.getByTestId("forbidAutogrowthInfo")).toBeInTheDocument();

--- a/src/components/project/ProjectTableDetails.js
+++ b/src/components/project/ProjectTableDetails.js
@@ -50,6 +50,7 @@ const ProjectTableDetails = (props) => {
   const { resetCommitmentTransfer } = useResetCommitment();
   // commitment query requires a domain ID that differs on cluster level.
   const scope = useGlobalStore((state) => state.scope);
+  const canEdit = useGlobalStore((state) => state.canEdit);
   const domainID = scope.isCluster() ? metadata.domainID : null;
   // only display the move commitment button on projects with a commitment on them.
   const moveCommitment = React.useMemo(() => {
@@ -148,9 +149,10 @@ const ProjectTableDetails = (props) => {
                     className={"ml-1"}
                     data-cy="moveCommitment"
                     variant="primary"
-                    disabled={!showCommitments || !moveCommitment || transferCommitment || isCommitting || isLoading}
+                    disabled={!showCommitments || !moveCommitment || transferCommitment || isCommitting || isLoading || !canEdit}
                     size="small"
                     onClick={() => {
+                      if (!canEdit) return;
                       setTransferCommitment(true);
                     }}
                   >
@@ -161,7 +163,9 @@ const ProjectTableDetails = (props) => {
                 <Button
                   variant="primary"
                   size="small"
+                  disabled={!canEdit}
                   onClick={() => {
+                    if (!canEdit) return;
                     handleCommitmentTransfer(project);
                   }}
                 >

--- a/src/components/project/ProjectTableDetails.js
+++ b/src/components/project/ProjectTableDetails.js
@@ -149,7 +149,9 @@ const ProjectTableDetails = (props) => {
                     className={"ml-1"}
                     data-cy="moveCommitment"
                     variant="primary"
-                    disabled={!showCommitments || !moveCommitment || transferCommitment || isCommitting || isLoading || !canEdit}
+                    disabled={
+                      !showCommitments || !moveCommitment || transferCommitment || isCommitting || isLoading || !canEdit
+                    }
                     size="small"
                     onClick={() => {
                       if (!canEdit) return;

--- a/src/components/shared/AddCommitments.js
+++ b/src/components/shared/AddCommitments.js
@@ -10,6 +10,7 @@ import { getResourceDurations } from "../../lib/utils";
 const AddCommitments = (props) => {
   const { label, size, disabled, resource, onClick } = props;
   const scope = useGlobalStore((state) => state.scope);
+  const canEdit = useGlobalStore((state) => state.canEdit);
   const { setCommitment } = createCommitmentStoreActions();
   const isCommitting = useCreateCommitmentStore((state) => state.isCommitting);
   const { setIsCommitting } = createCommitmentStoreActions();
@@ -21,6 +22,7 @@ const AddCommitments = (props) => {
         data-testid="addCommitment"
         data-cy="addCommitment"
         onClick={() => {
+          if (!canEdit) return;
           // Call the passed onClick handler first (e.g., to open the project)
           onClick?.();
           // On Cluster/Domain View a project can be transferred, therefore we reset it first
@@ -31,7 +33,7 @@ const AddCommitments = (props) => {
           setIsCommitting(true);
         }}
         variant="primary"
-        disabled={disabled || isCommitting}
+        disabled={disabled || isCommitting || !canEdit}
         icon={scope.isProject() ? "addCircle" : undefined}
         size={size}
       >

--- a/src/components/shared/MergeCommitments.js
+++ b/src/components/shared/MergeCommitments.js
@@ -3,20 +3,23 @@
 
 import React from "react";
 import { Button, Icon, Stack } from "@cloudoperators/juno-ui-components";
+import { useGlobalStore } from "../StoreProvider";
 
 const MergeCommitment = (props) => {
   const { mergeOps, style } = props;
   const { isMerging, setIsMerging, commitmentsToMerge, setCommitmentsToMerge, setConfirmMerge, mergeIsActive } =
     mergeOps;
+  const canEdit = useGlobalStore((state) => state.canEdit);
 
   return (
     <Stack className={style} gap="1">
       <Button
         data-testid={"mergeToggle"}
-        disabled={!mergeIsActive}
+        disabled={!mergeIsActive || !canEdit}
         title={!isMerging ? "Merge" : "Cancel Merge"}
         size="small"
         onClick={() => {
+          if (!canEdit) return;
           if (isMerging) {
             setCommitmentsToMerge([]);
           }
@@ -32,9 +35,10 @@ const MergeCommitment = (props) => {
         className={!isMerging && "invisible"}
         size="small"
         icon="success"
-        disabled={commitmentsToMerge.length < 2}
+        disabled={commitmentsToMerge.length < 2 || !canEdit}
         variant="primary"
         onClick={() => {
+          if (!canEdit) return;
           setConfirmMerge(true);
         }}
       />

--- a/src/components/shared/useMaxQuotaSets.js
+++ b/src/components/shared/useMaxQuotaSets.js
@@ -3,7 +3,7 @@
 
 import React from "react";
 import { useMutation } from "@tanstack/react-query";
-import { projectStoreActions } from "../StoreProvider";
+import { projectStoreActions, useGlobalStore } from "../StoreProvider";
 import { Button, Stack } from "@cloudoperators/juno-ui-components";
 import { createCommitmentStoreActions } from "../StoreProvider";
 import { createUnit, valueWithUnit } from "../../lib/unit";
@@ -150,6 +150,7 @@ const MaxQuotaEdit = (props) => {
     subduedView = false,
   } = props;
   const { styles = "" } = props;
+  const canEdit = useGlobalStore((state) => state.canEdit);
 
   const { isEditing = false, isLoading = false } = maxQuotaState;
 
@@ -160,7 +161,9 @@ const MaxQuotaEdit = (props) => {
       icon="edit"
       size="small"
       variant={subduedView ? "subdued" : "primary"}
+      disabled={!canEdit}
       onClick={() => {
+        if (!canEdit) return;
         handleEdit();
       }}
     >

--- a/src/components/shared/useMaxQuotaSets.test.js
+++ b/src/components/shared/useMaxQuotaSets.test.js
@@ -3,9 +3,9 @@
 
 import React from "react";
 import useMaxQuotaSets from "./useMaxQuotaSets";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { PortalProvider } from "@cloudoperators/juno-ui-components";
-import StoreProvider from "../StoreProvider";
+import StoreProvider, { globalStoreActions } from "../StoreProvider";
 
 const ExampleCMP = ({ project, resource, serviceType, postMaxQuota = () => {} }) => {
   const { MaxQuotaInput, maxQuotaInputProps, MaxQuotaEdit, maxQuotaEditProps } = useMaxQuotaSets({
@@ -41,13 +41,28 @@ describe("test useMaxQuotaSets", () => {
       expect(projectID).toEqual(12);
       expect(domainID).toEqual(13);
     });
-    render(
+
+    const wrapper = ({ children }) => (
       <PortalProvider>
         <StoreProvider>
           <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} postMaxQuota={postMaxQuota} />
+          {children}
         </StoreProvider>
       </PortalProvider>
     );
+
+    const { result } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+
+    // Set canEdit to true to enable the Edit button
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+
     expect(screen.queryByText(/not set/i)).not.toBe(null);
     const editButton = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton);
@@ -62,13 +77,28 @@ describe("test useMaxQuotaSets", () => {
   test("should display max quota value as default input", () => {
     const project = { metadata: { name: "testProject", id: 12, domainID: 13 } };
     const resource = { usage: 8, quota: 10, max_quota: 9 };
-    render(
+
+    const wrapper = ({ children }) => (
       <PortalProvider>
         <StoreProvider>
           <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} />
+          {children}
         </StoreProvider>
       </PortalProvider>
     );
+
+    const { result } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+
+    // Set canEdit to true to enable the Edit button
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+
     const editButton = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton);
     const cancelButton = screen.getByTestId("maxQuotaCancel");
@@ -84,13 +114,28 @@ describe("test useMaxQuotaSets", () => {
     const project = { metadata: { name: "testProject", id: 12, domainID: 13 } };
     const resource = { usage: 512, quota: 1024, max_quota: 1024, unit: "MiB" };
     const postMaxQuota = jest.fn(() => {});
-    render(
+
+    const wrapper = ({ children }) => (
       <PortalProvider>
         <StoreProvider>
           <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} postMaxQuota={postMaxQuota} />
+          {children}
         </StoreProvider>
       </PortalProvider>
     );
+
+    const { result } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+
+    // Set canEdit to true to enable the Edit button
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+
     expect(screen.queryByText(/1 gib/i)).not.toBe(null);
     // false input (no unit)
     const editButton = screen.getByTestId("maxQuotaEdit");
@@ -108,13 +153,28 @@ describe("test useMaxQuotaSets", () => {
     const project = { metadata: { name: "testProject", id: 12, domainID: 13 } };
     const resource = { usage: 1, quota: 5, max_quota: 5, unit: "128 GiB" };
     const postMaxQuota = jest.fn(() => {});
-    render(
+
+    const wrapper = ({ children }) => (
       <PortalProvider>
         <StoreProvider>
           <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} postMaxQuota={postMaxQuota} />
+          {children}
         </StoreProvider>
       </PortalProvider>
     );
+
+    const { result } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+
+    // Set canEdit to true to enable the Edit button
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+
     expect(screen.queryByText(/640 GiB/i)).not.toBe(null);
     const editButton = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton);
@@ -130,13 +190,28 @@ describe("test useMaxQuotaSets", () => {
     const project = { metadata: { name: "testProject", id: 12, domainID: 13 } };
     const resource = { usage: 8, quota: 10, max_quota: 10 };
     const postMaxQuota = jest.fn(() => {});
-    render(
+
+    const wrapper = ({ children }) => (
       <PortalProvider>
         <StoreProvider>
           <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} postMaxQuota={postMaxQuota} />
+          {children}
         </StoreProvider>
       </PortalProvider>
     );
+
+    const { result } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+
+    // Set canEdit to true to enable the Edit button
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+
     const editButton = screen.getByTestId("maxQuotaEdit");
     fireEvent.click(editButton);
     const quotaInput = screen.getByTestId("inputWithUnit");
@@ -146,5 +221,40 @@ describe("test useMaxQuotaSets", () => {
     await waitFor(() => {
       expect(postMaxQuota).not.toHaveBeenCalled();
     });
+  });
+
+  test("Edit button should be visible depending on the canEdit state", async () => {
+    const project = { metadata: { name: "testProject", id: 12, domainID: 13 } };
+    const resource = { usage: 8, quota: 10, max_quota: 10 };
+
+    const wrapper = ({ children }) => (
+      <PortalProvider>
+        <StoreProvider>
+          <ExampleCMP project={project} resource={resource} serviceType={"serviceA"} />
+          {children}
+        </StoreProvider>
+      </PortalProvider>
+    );
+
+    const { result, rerender } = renderHook(
+      () => ({
+        globalStoreActions: globalStoreActions(),
+      }),
+      { wrapper }
+    );
+
+    // Set canEdit to true - button should be enabled (positive test)
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(true);
+    });
+    const editButton = screen.getByTestId("maxQuotaEdit");
+    expect(editButton).toBeEnabled();
+
+    // Edit button should be disabled when canEdit is false (viewer role).
+    rerender();
+    act(() => {
+      result.current.globalStoreActions.setCanEdit(false);
+    });
+    expect(editButton).toBeDisabled();
   });
 });

--- a/src/lib/store/limesStore.js
+++ b/src/lib/store/limesStore.js
@@ -137,8 +137,14 @@ const limesStore = (set, get) => ({
   },
   global: {
     scope: new Scope(),
+    canEdit: false,
 
     actions: {
+      setCanEdit: (canEdit) => {
+        set((state) => ({
+          global: { ...state.global, canEdit: canEdit },
+        }));
+      },
       setScope: (scope) => {
         set((state) => ({
           global: { ...state.global, scope: scope },


### PR DESCRIPTION
The UI would previously disable the EditPanel for users with a viewer role.
Due to changed requirements, they should also see the contents in the EditPanel, but should not be able to perform actions.
The updated version ensures that the user can only interact with viewable elements.