### PR TITLE
fix: quota panel regressions

### DIFF
--- a/.changeset/better-walls-wink.md
+++ b/.changeset/better-walls-wink.md
@@ -1,0 +1,5 @@
+---
+"@sapcc/limes-ui": patch
+---
+
+fix quota panel; don't fetch public commitments; Adjust setRefetchProject API parameter on domain / cluster level

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -100,7 +100,7 @@ const EditPanel = (props) => {
 
   const publicCommitmentQuery = useQuery({
     queryKey: ["publicCommitments", { service: serviceType, resource: currentResource.name }],
-    enabled: !subRoute
+    enabled: !subRoute,
   });
 
   // Query can-confirm API. Determine if capacity is sufficient on limes.

--- a/src/components/panel/EditPanel.js
+++ b/src/components/panel/EditPanel.js
@@ -100,6 +100,7 @@ const EditPanel = (props) => {
 
   const publicCommitmentQuery = useQuery({
     queryKey: ["publicCommitments", { service: serviceType, resource: currentResource.name }],
+    enabled: !subRoute
   });
 
   // Query can-confirm API. Determine if capacity is sufficient on limes.

--- a/src/components/shared/useMaxQuotaSets.js
+++ b/src/components/shared/useMaxQuotaSets.js
@@ -24,6 +24,7 @@ const useMaxQuotaSets = (props) => {
 
   React.useEffect(() => {
     if (!maxQuotaState.isLoading) return;
+    inputRef.current = maxQuotaDefaultInput;
     setMaxQuotaState({ ...maxQuotaState, isEditing: false, isLoading: false });
   }, [resource]);
 
@@ -211,7 +212,7 @@ function getMaxQuotaQuery() {
       { payload: project, targetDomain: domainID, targetProject: projectID },
       {
         onSuccess: () => {
-          setRefetchProjectAPI(true);
+          setRefetchProjectAPI(domainID ? [domainID] : []);
         },
         onError: (error) => {
           setToast(error.toString());


### PR DESCRIPTION
A subroute should not fetch for public commitments
Adjust setRefetchProjectAPI to only fetch for the specific domain. This fixes a broken loading state on the max-Quota save button.